### PR TITLE
Perf improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,6 +97,9 @@ jobs:
           - os: macos-latest
             ghc: 8.10.7
 
+    env:
+      GHC_VERSION=$(echo ${{ matrix.ghc }} | tr -d .)
+
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v3
@@ -112,5 +115,13 @@ jobs:
 
       - name: Build Packages
         run: |
-          GHC_VERSION=$(echo ${{ matrix.ghc }} | tr -d .)
-          nix build -L --no-link .#webgear-core-ghc${GHC_VERSION} .#webgear-server-ghc${GHC_VERSION} .#webgear-openapi-ghc${GHC_VERSION}
+          nix build --print-build-logs --no-link   \
+            .#webgear-core-ghc${GHC_VERSION}       \
+            .#webgear-server-ghc${GHC_VERSION}     \
+            .#webgear-openapi-ghc${GHC_VERSION}    \
+            .#webgear-benchmarks-ghc${GHC_VERSION}
+
+      - name: Benchmark
+        run: |
+          BENCHMARK=$(nix build --no-link --json .#webgear-benchmarks-ghc${GHC_VERSION} | jq -r .[].outputs.out)
+          ${BENCHMARK}/bin/users

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,4 +123,4 @@ jobs:
         run: |
           GHC_VERSION=$(echo ${{ matrix.ghc }} | tr -d .)
           BENCHMARK=$(nix build --no-link --json .#webgear-benchmarks-ghc${GHC_VERSION} | jq -r .[].outputs.out)
-          ${BENCHMARK}/bin/users
+          ${BENCHMARK}/bin/users +RTS -N -RTS

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,9 +97,6 @@ jobs:
           - os: macos-latest
             ghc: 8.10.7
 
-    env:
-      GHC_VERSION=$(echo ${{ matrix.ghc }} | tr -d .)
-
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v3
@@ -115,6 +112,7 @@ jobs:
 
       - name: Build Packages
         run: |
+          GHC_VERSION=$(echo ${{ matrix.ghc }} | tr -d .)
           nix build --print-build-logs --no-link   \
             .#webgear-core-ghc${GHC_VERSION}       \
             .#webgear-server-ghc${GHC_VERSION}     \
@@ -123,5 +121,6 @@ jobs:
 
       - name: Benchmark
         run: |
+          GHC_VERSION=$(echo ${{ matrix.ghc }} | tr -d .)
           BENCHMARK=$(nix build --no-link --json .#webgear-benchmarks-ghc${GHC_VERSION} | jq -r .[].outputs.out)
           ${BENCHMARK}/bin/users

--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,4 @@
 packages: webgear-core/
           webgear-server/
           webgear-openapi/
+          webgear-benchmarks/

--- a/hie.yaml
+++ b/hie.yaml
@@ -20,3 +20,8 @@ cradle:
         cradle:
           cabal:
             component: "lib:webgear-openapi"
+    - path: "./webgear-benchmarks/src"
+      config:
+        cradle:
+          cabal:
+            component: "exe:users"

--- a/nix/overlays/haskell.nix
+++ b/nix/overlays/haskell.nix
@@ -12,6 +12,7 @@ let
     "webgear-core" = ../../webgear-core;
     "webgear-server" = ../../webgear-server;
     "webgear-openapi" = ../../webgear-openapi;
+    "webgear-benchmarks" = ../../webgear-benchmarks;
   };
 
   mkLocalDerivation = hspkgs: name: path:

--- a/stack-8.10.7.yaml
+++ b/stack-8.10.7.yaml
@@ -5,3 +5,7 @@ packages:
   - ./webgear-server
   - ./webgear-openapi
   - ./webgear-benchmarks
+
+extra-deps:
+  - servant-0.19@sha256:8d1119c20d6eccb56e308642ec376eaa1b267a8dd761aa85a10e299e64371e3c,5562
+  - servant-server-0.19.1@sha256:e5788f21872a045ab588f2c93d538791f21623f5c1b9885952348a147a095aa1,5709

--- a/stack-8.10.7.yaml
+++ b/stack-8.10.7.yaml
@@ -4,3 +4,4 @@ packages:
   - ./webgear-core
   - ./webgear-server
   - ./webgear-openapi
+  - ./webgear-benchmarks

--- a/stack-8.10.7.yaml.lock
+++ b/stack-8.10.7.yaml.lock
@@ -3,7 +3,21 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    pantry-tree:
+      sha256: 20fd58aaba4380d0575ce8d61884440d6063c6509a57a7540bb8bce8c02e44a9
+      size: 2802
+    hackage: servant-0.19@sha256:8d1119c20d6eccb56e308642ec376eaa1b267a8dd761aa85a10e299e64371e3c,5562
+  original:
+    hackage: servant-0.19@sha256:8d1119c20d6eccb56e308642ec376eaa1b267a8dd761aa85a10e299e64371e3c,5562
+- completed:
+    pantry-tree:
+      sha256: 5822e994d8b57b859f15c877931aee031b9f7182ba9ef5c03cac3b05e2303c37
+      size: 2614
+    hackage: servant-server-0.19.1@sha256:e5788f21872a045ab588f2c93d538791f21623f5c1b9885952348a147a095aa1,5709
+  original:
+    hackage: servant-server-0.19.1@sha256:e5788f21872a045ab588f2c93d538791f21623f5c1b9885952348a147a095aa1,5709
 snapshots:
 - completed:
     sha256: 428ec8d5ce932190d3cbe266b9eb3c175cd81e984babf876b64019e2cbe4ea68

--- a/stack-9.0.2.yaml
+++ b/stack-9.0.2.yaml
@@ -4,3 +4,4 @@ packages:
   - ./webgear-core
   - ./webgear-server
   - ./webgear-openapi
+  - ./webgear-benchmarks

--- a/stack-9.2.3.yaml
+++ b/stack-9.2.3.yaml
@@ -4,3 +4,4 @@ packages:
   - ./webgear-core
   - ./webgear-server
   - ./webgear-openapi
+  - ./webgear-benchmarks

--- a/webgear-benchmarks/LICENSE
+++ b/webgear-benchmarks/LICENSE
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/webgear-benchmarks/README.md
+++ b/webgear-benchmarks/README.md
@@ -1,0 +1,44 @@
+# WebGear Benchmarking
+Some benchmarks comparing webgear against other Haskell web frameworks.
+
+## Users benchmark
+
+### Criterion
+This benchmark runs a sequence of PUT, GET, and DELETE operations with criterion. This can be run with the following
+command:
+
+```
+stack bench --ba "--time-limit 15"
+```
+
+### Results
+
+```
+webgear-benchmarks> benchmarks
+Running 1 benchmarks...
+Benchmark bench-users: RUNNING...
+benchmarking webgear
+time                 23.67 ms   (22.33 ms .. 25.24 ms)
+                     0.981 R²   (0.971 R² .. 0.990 R²)
+mean                 26.11 ms   (25.50 ms .. 26.45 ms)
+std dev              1.484 ms   (1.023 ms .. 1.934 ms)
+variance introduced by outliers: 29% (moderately inflated)
+
+benchmarking servant
+time                 24.06 ms   (23.54 ms .. 24.34 ms)
+                     0.994 R²   (0.984 R² .. 1.000 R²)
+mean                 23.97 ms   (23.60 ms .. 24.25 ms)
+std dev              963.9 μs   (493.0 μs .. 1.479 ms)
+variance introduced by outliers: 17% (moderately inflated)
+
+benchmarking scotty
+time                 28.91 ms   (27.54 ms .. 30.82 ms)
+                     0.983 R²   (0.974 R² .. 0.990 R²)
+mean                 33.29 ms   (32.42 ms .. 33.99 ms)
+std dev              2.300 ms   (1.799 ms .. 2.793 ms)
+variance introduced by outliers: 36% (moderately inflated)
+
+Benchmark bench-users: FINISH
+```
+
+These benchmarks were run on a MacBook Pro 2019, Intel Core i7, 6-core 2.6 GHz, 32 GB RAM.

--- a/webgear-benchmarks/README.md
+++ b/webgear-benchmarks/README.md
@@ -7,38 +7,72 @@ Some benchmarks comparing webgear against other Haskell web frameworks.
 This benchmark runs a sequence of PUT, GET, and DELETE operations with criterion. This can be run with the following
 command:
 
-```
-stack bench --ba "--time-limit 15"
-```
-
-### Results
-
-```
-webgear-benchmarks> benchmarks
-Running 1 benchmarks...
-Benchmark bench-users: RUNNING...
-benchmarking webgear
-time                 23.67 ms   (22.33 ms .. 25.24 ms)
-                     0.981 R²   (0.971 R² .. 0.990 R²)
-mean                 26.11 ms   (25.50 ms .. 26.45 ms)
-std dev              1.484 ms   (1.023 ms .. 1.934 ms)
-variance introduced by outliers: 29% (moderately inflated)
-
-benchmarking servant
-time                 24.06 ms   (23.54 ms .. 24.34 ms)
-                     0.994 R²   (0.984 R² .. 1.000 R²)
-mean                 23.97 ms   (23.60 ms .. 24.25 ms)
-std dev              963.9 μs   (493.0 μs .. 1.479 ms)
-variance introduced by outliers: 17% (moderately inflated)
-
-benchmarking scotty
-time                 28.91 ms   (27.54 ms .. 30.82 ms)
-                     0.983 R²   (0.974 R² .. 0.990 R²)
-mean                 33.29 ms   (32.42 ms .. 33.99 ms)
-std dev              2.300 ms   (1.799 ms .. 2.793 ms)
-variance introduced by outliers: 36% (moderately inflated)
-
-Benchmark bench-users: FINISH
+```shell
+nix develop .#webgear-dev-ghc<GHC-VERSION>
+cabal run users
 ```
 
-These benchmarks were run on a MacBook Pro 2019, Intel Core i7, 6-core 2.6 GHz, 32 GB RAM.
+### Sample Results
+
+```
+Build profile: -w ghc-9.0.2 -O1
+In order, the following will be built (use -v for more details):
+ - webgear-benchmarks-1.0.4 (exe:users) (file README.md changed)
+Preprocessing executable 'users' for webgear-benchmarks-1.0.4..
+Building executable 'users' for webgear-benchmarks-1.0.4..
+benchmarking webgear/500
+time                 8.388 ms   (8.159 ms .. 8.754 ms)
+                     0.974 R²   (0.921 R² .. 0.998 R²)
+mean                 8.522 ms   (8.334 ms .. 9.024 ms)
+std dev              773.3 μs   (373.6 μs .. 1.426 ms)
+variance introduced by outliers: 51% (severely inflated)
+
+benchmarking webgear/1000
+time                 16.88 ms   (16.56 ms .. 17.24 ms)
+                     0.997 R²   (0.995 R² .. 0.999 R²)
+mean                 17.30 ms   (17.13 ms .. 17.58 ms)
+std dev              529.1 μs   (366.9 μs .. 795.7 μs)
+
+benchmarking webgear/5000
+time                 88.47 ms   (86.15 ms .. 92.22 ms)
+                     0.995 R²   (0.983 R² .. 1.000 R²)
+mean                 87.48 ms   (86.17 ms .. 90.66 ms)
+std dev              3.272 ms   (1.291 ms .. 5.392 ms)
+
+benchmarking servant/500
+time                 9.350 ms   (9.188 ms .. 9.487 ms)
+                     0.999 R²   (0.997 R² .. 1.000 R²)
+mean                 9.569 ms   (9.498 ms .. 9.701 ms)
+std dev              251.7 μs   (160.4 μs .. 392.9 μs)
+
+benchmarking servant/1000
+time                 19.01 ms   (18.86 ms .. 19.16 ms)
+                     1.000 R²   (0.999 R² .. 1.000 R²)
+mean                 19.09 ms   (18.98 ms .. 19.27 ms)
+std dev              322.7 μs   (186.3 μs .. 551.0 μs)
+
+benchmarking servant/5000
+time                 95.47 ms   (93.92 ms .. 97.35 ms)
+                     1.000 R²   (0.999 R² .. 1.000 R²)
+mean                 95.16 ms   (94.46 ms .. 96.06 ms)
+std dev              1.258 ms   (789.2 μs .. 1.913 ms)
+
+benchmarking scotty/500
+time                 13.23 ms   (13.08 ms .. 13.37 ms)
+                     0.999 R²   (0.999 R² .. 1.000 R²)
+mean                 13.30 ms   (13.24 ms .. 13.40 ms)
+std dev              205.2 μs   (139.9 μs .. 316.2 μs)
+
+benchmarking scotty/1000
+time                 27.12 ms   (26.21 ms .. 28.57 ms)
+                     0.995 R²   (0.989 R² .. 1.000 R²)
+mean                 26.77 ms   (26.55 ms .. 27.35 ms)
+std dev              728.5 μs   (342.2 μs .. 1.272 ms)
+
+benchmarking scotty/5000
+time                 131.1 ms   (126.4 ms .. 138.6 ms)
+                     0.999 R²   (0.997 R² .. 1.000 R²)
+mean                 132.8 ms   (131.5 ms .. 134.9 ms)
+std dev              2.602 ms   (937.7 μs .. 3.331 ms)
+variance introduced by outliers: 11% (moderately inflated)
+```

--- a/webgear-benchmarks/src/users/Main.hs
+++ b/webgear-benchmarks/src/users/Main.hs
@@ -1,0 +1,90 @@
+{-# OPTIONS_GHC -Wno-error=deprecations #-}
+
+module Main where
+
+import Criterion.Main (bench, bgroup, defaultMain, nfIO)
+import Data.ByteString (ByteString)
+import Data.IORef (newIORef, readIORef, writeIORef)
+import Network.HTTP.Types (methodDelete, methodGet, methodPut, statusCode)
+import Network.Wai (Application, defaultRequest)
+import Network.Wai.Internal (Request (..), Response (..), ResponseReceived (..))
+import System.Environment (getArgs)
+
+import qualified Scotty
+import qualified Servant
+import qualified WebGear
+
+import Control.Monad
+import Model (newStore)
+
+main :: IO ()
+main = do
+  store <- newStore
+
+  let mkBenchmark name test =
+        bgroup name $
+          map (\count -> bench (show count) $ nfIO $ test count) [500, 1000, 5000]
+
+  let webgear = mkBenchmark "webgear" (\n -> runTest n $ WebGear.application store)
+  let servant = mkBenchmark "servant" (\n -> runTest n $ Servant.application store)
+  let scotty = mkBenchmark "scotty" (\n -> Scotty.application store >>= runTest n)
+
+  getArgs >>= \case
+    ["webgear"] -> defaultMain [webgear]
+    ["servant"] -> defaultMain [servant]
+    ["scotty"] -> defaultMain [scotty]
+    _ -> defaultMain [webgear, servant, scotty]
+
+runTest :: Int -> Application -> IO ()
+runTest count app = replicateM_ count $ do
+  _ <- app getRequest (respond 404)
+  _ <- putRequest >>= flip app (respond 200)
+  _ <- app getRequest (respond 200)
+  _ <- app deleteRequest (respond 204)
+  return ()
+
+putRequest :: IO Request
+putRequest = do
+  f <- bodyGetter "{\"userId\": 1, \"userName\": \"John Doe\", \"dateOfBirth\": \"2000-03-01\", \"gender\": \"Male\", \"emailAddress\": \"john@example.com\"}"
+  return
+    defaultRequest
+      { requestMethod = methodPut
+      , requestHeaders = [("Content-type", "application/json")]
+      , pathInfo = ["v1", "users", "1"]
+      , requestBody = f
+      }
+
+bodyGetter :: ByteString -> IO (IO ByteString)
+bodyGetter s = do
+  ref <- newIORef (Just s)
+  pure $
+    readIORef ref >>= \case
+      Nothing -> pure ""
+      Just x -> writeIORef ref Nothing >> return x
+
+getRequest :: Request
+getRequest =
+  defaultRequest
+    { requestMethod = methodGet
+    , pathInfo = ["v1", "users", "1"]
+    }
+
+deleteRequest :: Request
+deleteRequest =
+  defaultRequest
+    { requestMethod = methodDelete
+    , pathInfo = ["v1", "users", "1"]
+    }
+
+respond :: Int -> Response -> IO ResponseReceived
+respond expectedStatus res = do
+  let actualStatus = statusOf res
+  when (expectedStatus /= actualStatus) $
+    putStrLn "Unexpected response status"
+  return ResponseReceived
+
+statusOf :: Response -> Int
+statusOf (ResponseFile status _ _ _) = statusCode status
+statusOf (ResponseBuilder status _ _) = statusCode status
+statusOf (ResponseStream status _ _) = statusCode status
+statusOf (ResponseRaw _ res) = statusOf res

--- a/webgear-benchmarks/src/users/Model.hs
+++ b/webgear-benchmarks/src/users/Model.hs
@@ -1,0 +1,52 @@
+module Model where
+
+import Control.Monad.IO.Class (MonadIO (..))
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Hashable (Hashable)
+import Data.IORef (IORef, modifyIORef, newIORef, readIORef)
+import Data.Maybe (isJust)
+import Data.Text (Text)
+import Data.Time.Calendar (Day)
+import GHC.Generics (Generic)
+
+import qualified Data.HashMap.Strict as HM
+
+--------------------------------------------------------------------------------
+-- Model for users
+--------------------------------------------------------------------------------
+data User = User
+  { userId :: UserId
+  , userName :: Text
+  , dateOfBirth :: Day
+  , gender :: Gender
+  , emailAddress :: Text
+  }
+  deriving stock (Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
+newtype UserId = UserId Int
+  deriving (Eq, FromJSON, ToJSON, Hashable) via Int
+
+data Gender = Male | Female | OtherGender
+  deriving stock (Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
+--------------------------------------------------------------------------------
+-- An in-memory store and associated operations for users
+--------------------------------------------------------------------------------
+newtype UserStore = UserStore (IORef (HM.HashMap UserId User))
+
+newStore :: MonadIO m => m UserStore
+newStore = UserStore <$> liftIO (newIORef HM.empty)
+
+addUser :: MonadIO m => UserStore -> User -> m ()
+addUser (UserStore ref) user = liftIO $ modifyIORef ref (HM.insert (userId user) user)
+
+lookupUser :: MonadIO m => UserStore -> UserId -> m (Maybe User)
+lookupUser (UserStore ref) uid = liftIO (HM.lookup uid <$> readIORef ref)
+
+removeUser :: MonadIO m => UserStore -> UserId -> m Bool
+removeUser store@(UserStore ref) uid = liftIO $ do
+  u <- lookupUser store uid
+  modifyIORef ref (HM.delete uid)
+  pure $ isJust u

--- a/webgear-benchmarks/src/users/Scotty.hs
+++ b/webgear-benchmarks/src/users/Scotty.hs
@@ -1,0 +1,42 @@
+module Scotty where
+
+import Network.HTTP.Types (noContent204, notFound404)
+import Network.Wai
+import Web.Scotty
+
+import Model
+
+application :: UserStore -> IO Application
+application store = scottyApp $ do
+  get "/v1/users/:userId" $ getUser store
+  put "/v1/users/:userId" $ putUser store
+  delete "/v1/users/:userId" $ deleteUser store
+
+getUser :: UserStore -> ActionM ()
+getUser store = do
+  uid <- param "userId"
+  lookupUser store (UserId uid) >>= \case
+    Just user -> json user
+    Nothing -> respondNotFound
+
+putUser :: UserStore -> ActionM ()
+putUser store = do
+  uid <- param "userId"
+  user <- jsonData
+  let user' = user{userId = UserId uid}
+  addUser store user'
+  json user'
+
+deleteUser :: UserStore -> ActionM ()
+deleteUser store = do
+  uid <- param "userId"
+  found <- removeUser store (UserId uid)
+  if found
+    then status noContent204 >> raw ""
+    else respondNotFound
+
+respondNotFound :: ActionM ()
+respondNotFound = do
+  status notFound404
+  text "Not found"
+  finish

--- a/webgear-benchmarks/src/users/Servant.hs
+++ b/webgear-benchmarks/src/users/Servant.hs
@@ -1,0 +1,73 @@
+module Servant where
+
+import Control.Monad.Except (ExceptT, MonadError, mapExceptT, throwError)
+import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.Reader (MonadReader, ReaderT, ask, runReaderT)
+import Data.Proxy (Proxy (..))
+import Network.Wai
+import Servant.API
+import Servant.Server
+
+import Model
+
+type UserAPI =
+  "v1" :> "users" :> Capture "userId" Int :> Get '[JSON] User
+    :<|> "v1" :> "users" :> Capture "userId" Int :> ReqBody '[JSON] User :> Put '[JSON] User
+    :<|> "v1" :> "users" :> Capture "userId" Int :> Verb DELETE 204 '[JSON] NoContent
+
+application :: UserStore -> Application
+application store = serve userAPI $ hoistServer userAPI toHandler server
+  where
+    toHandler :: UserHandler a -> Handler a
+    toHandler = Handler . mapExceptT f
+
+    f :: ReaderT UserStore IO (Either ServerError a) -> IO (Either ServerError a)
+    f x = runReaderT x store
+
+userAPI :: Proxy UserAPI
+userAPI = Proxy
+
+type UserHandler = ExceptT ServerError (ReaderT UserStore IO)
+
+server :: ServerT UserAPI UserHandler
+server = getUser :<|> putUser :<|> deleteUser
+
+getUser ::
+  ( MonadReader UserStore m
+  , MonadError ServerError m
+  , MonadIO m
+  ) =>
+  Int ->
+  m User
+getUser uid = do
+  store <- ask
+  lookupUser store (UserId uid) >>= \case
+    Just user -> return user
+    Nothing -> throwError err404
+
+putUser ::
+  ( MonadReader UserStore m
+  , MonadIO m
+  ) =>
+  Int ->
+  User ->
+  m User
+putUser uid user = do
+  let user' = user{userId = UserId uid}
+  store <- ask
+  addUser store user'
+  return user'
+
+deleteUser ::
+  ( MonadReader UserStore m
+  , MonadError ServerError m
+  , MonadIO m
+  ) =>
+  Int ->
+  m NoContent
+deleteUser uid = do
+  store <- ask
+  found <- removeUser store (UserId uid)
+  if found
+    then return NoContent
+    else throwError err404

--- a/webgear-benchmarks/src/users/WebGear.hs
+++ b/webgear-benchmarks/src/users/WebGear.hs
@@ -1,0 +1,110 @@
+module WebGear where
+
+import Control.Arrow
+import Control.Monad.Reader (MonadReader (..), ReaderT (..))
+import Model
+import Network.HTTP.Types (StdMethod (..))
+import qualified Network.HTTP.Types as HTTP
+import Network.Wai (Application)
+import WebGear.Server
+
+--------------------------------------------------------------------------------
+-- Routes of the API
+--------------------------------------------------------------------------------
+-- The route handlers run in the App monad
+type AppM = ReaderT UserStore IO
+
+type UserIdPathVar = PathVar "userId" Int
+
+allRoutes ::
+  StdHandler
+    h
+    AppM
+    [UserIdPathVar, JSONBody User]
+    [Body Text, RequiredHeader "Content-Type" Text, JSONBody User] =>
+  h (Linked '[] Request) Response
+allRoutes =
+  -- TH version: [route| /v1/users/userId:Int |]
+  path "/v1/users" $
+    pathVar @"userId" @Int $
+      pathEnd $
+        method GET getUser
+          <+> method PUT putUser
+          <+> method DELETE deleteUser
+
+getUser ::
+  forall h req.
+  ( HasTrait UserIdPathVar req
+  , StdHandler h AppM '[] [RequiredHeader "Content-Type" Text, JSONBody User]
+  ) =>
+  h (Linked req Request) Response
+getUser = findUser >>> respond
+  where
+    findUser :: h (Linked req Request) (Maybe User)
+    findUser = arrM $ \request -> do
+      let uid = pick @UserIdPathVar $ from request
+      store <- ask
+      lookupUser store (UserId uid)
+
+    respond :: h (Maybe User) Response
+    respond = proc maybeUser -> case maybeUser of
+      Nothing -> unlinkA <<< notFound404 -< ()
+      Just u -> unlinkA <<< respondJsonA HTTP.ok200 -< u
+
+putUser ::
+  forall h req.
+  ( HasTrait UserIdPathVar req
+  , StdHandler
+      h
+      AppM
+      '[JSONBody User]
+      [RequiredHeader "Content-Type" Text, JSONBody User, Body Text]
+  ) =>
+  h (Linked req Request) Response
+putUser = jsonRequestBody @User badPayload $ doUpdate >>> respond
+  where
+    badPayload :: h (Linked req Request, Text) Response
+    badPayload = proc _ ->
+      unlinkA <<< respondA HTTP.badRequest400 "text/plain" -< "Invalid body payload" :: Text
+
+    doUpdate :: HaveTraits [UserIdPathVar, JSONBody User] ts => h (Linked ts Request) User
+    doUpdate = arrM $ \request -> do
+      let uid = pick @UserIdPathVar $ from request
+          user = pick @(JSONBody User) $ from request
+          user' = user{userId = UserId uid}
+      store <- ask
+      addUser store user'
+      pure user'
+
+    respond :: h User Response
+    respond = proc user ->
+      unlinkA <<< respondJsonA HTTP.ok200 -< user
+
+deleteUser ::
+  forall h req.
+  (HasTrait UserIdPathVar req, StdHandler h AppM '[] '[]) =>
+  h (Linked req Request) Response
+deleteUser = doDelete >>> respond
+  where
+    doDelete :: h (Linked req Request) Bool
+    doDelete = arrM $ \request -> do
+      let uid = pick @UserIdPathVar $ from request
+      store <- ask
+      removeUser store (UserId uid)
+
+    respond :: h Bool Response
+    respond = proc removed ->
+      if removed
+        then unlinkA <<< noContent204 -< ()
+        else unlinkA <<< notFound404 -< ()
+
+--------------------------------------------------------------------------------
+
+-- | The application server
+
+--------------------------------------------------------------------------------
+application :: UserStore -> Application
+application store = toApplication $ transform appToRouter allRoutes
+  where
+    appToRouter :: AppM a -> IO a
+    appToRouter = flip runReaderT store

--- a/webgear-benchmarks/user.json
+++ b/webgear-benchmarks/user.json
@@ -1,0 +1,1 @@
+{"userId": 1, "userName": "John Doe", "dateOfBirth": "2000-03-01", "gender": "Male", "emailAddress": "john@example.com"}

--- a/webgear-benchmarks/webgear-benchmarks.cabal
+++ b/webgear-benchmarks/webgear-benchmarks.cabal
@@ -19,7 +19,7 @@ source-repository head
 
 executable users
   default-language:   Haskell2010
-  build-depends:      aeson ==2.0.3.0
+  build-depends:      aeson >=1.5 && <2.1
                     , base >=4.14.0.0 && <5
                     , bytestring >=0.10 && <0.12
                     , criterion ==1.5.*
@@ -28,7 +28,7 @@ executable users
                     , mtl ==2.2.2
                     , text ==1.2.*
                     , time
-                    , unordered-containers ==0.2.17.0
+                    , unordered-containers ==0.2.*
                     , servant ==0.19
                     , servant-server ==0.19.1
                     , scotty ==0.12

--- a/webgear-benchmarks/webgear-benchmarks.cabal
+++ b/webgear-benchmarks/webgear-benchmarks.cabal
@@ -1,0 +1,73 @@
+cabal-version:       2.4
+name:                webgear-benchmarks
+version:             1.0.4
+description:         Benchmarks for webgear
+homepage:            https://github.com/haskell-webgear/webgear-benchmarks#readme
+bug-reports:         https://github.com/haskell-webgear/webgear-benchmarks/issues
+author:              Raghu Kaippully
+maintainer:          rkaippully@gmail.com
+copyright:           2020-2022 Raghu Kaippully
+license:             MPL-2.0
+license-file:        LICENSE
+build-type:          Simple
+extra-source-files:  README.md
+
+
+source-repository head
+  type:      git
+  location:  https://github.com/haskell-webgear/webgear-benchmarks
+
+executable users
+  default-language:   Haskell2010
+  build-depends:      aeson ==2.0.3.0
+                    , base >=4.14.0.0 && <5
+                    , bytestring >=0.10 && <0.12
+                    , criterion ==1.5.*
+                    , hashable >=1.3 && <1.5
+                    , http-types ==0.12.3
+                    , mtl ==2.2.2
+                    , text ==1.2.*
+                    , time
+                    , unordered-containers ==0.2.17.0
+                    , servant ==0.19
+                    , servant-server ==0.19.1
+                    , scotty ==0.12
+                    , wai ==3.2.3
+                    , webgear-server ==1.0.4
+  default-extensions: Arrows
+                      DataKinds
+                      DeriveAnyClass
+                      DeriveGeneric
+                      DerivingVia
+                      FlexibleContexts
+                      GeneralizedNewtypeDeriving
+                      LambdaCase
+                      OverloadedStrings
+                      QuasiQuotes
+                      RankNTypes
+                      ScopedTypeVariables
+                      TypeApplications
+                      TypeOperators
+  hs-source-dirs:     src/users
+  main-is:            Main.hs
+  other-modules:      Model
+                    , WebGear
+                    , Servant
+                    , Scotty
+  ghc-options:        -O2
+                      -threaded
+                      -rtsopts
+                      -Wall
+                      -Wno-unticked-promoted-constructors
+                      -Wcompat
+                      -Widentities
+                      -Wincomplete-record-updates
+                      -Wincomplete-uni-patterns
+                      -Wmissing-fields
+                      -Wmissing-home-modules
+                      -Wmissing-deriving-strategies
+                      -Wpartial-fields
+                      -Wredundant-constraints
+                      -Wunused-packages
+                      -Werror
+                      -fshow-warning-groups

--- a/webgear-core/src/WebGear/Core/Handler.hs
+++ b/webgear-core/src/WebGear/Core/Handler.hs
@@ -82,7 +82,9 @@ instance Monoid RouteMismatch where
 -- | Indicates that the request does not match the current handler.
 routeMismatch :: ArrowError RouteMismatch h => h a b
 routeMismatch = proc _a -> raise -< RouteMismatch
+{-# INLINE routeMismatch #-}
 
 -- | Lifts `unlink` into a handler arrow.
 unlinkA :: Handler h m => h (Linked ts Response) Response
 unlinkA = arr unlink
+{-# INLINE unlinkA #-}

--- a/webgear-core/src/WebGear/Core/Trait.hs
+++ b/webgear-core/src/WebGear/Core/Trait.hs
@@ -150,10 +150,12 @@ class HasTrait t ts where
 instance HasTrait t (t : ts) where
   from :: Linked (t : ts) a -> Tagged t (Attribute t a)
   from (Linked (lv, _) _) = Tagged lv
+  {-# INLINE from #-}
 
 instance {-# OVERLAPPABLE #-} HasTrait t ts => HasTrait t (t' : ts) where
   from :: Linked (t' : ts) a -> Tagged t (Attribute t a)
   from l = from $ linkminus l
+  {-# INLINE from #-}
 
 {- | Retrieve a trait.
 

--- a/webgear-core/src/WebGear/Core/Trait/Auth/Basic.hs
+++ b/webgear-core/src/WebGear/Core/Trait/Auth/Basic.hs
@@ -147,6 +147,7 @@ basicAuthMiddleware authCfg errorHandler nextHandler =
     case result of
       Left err -> errorHandler -< (request, err)
       Right val -> nextHandler -< val
+{-# INLINE basicAuthMiddleware #-}
 
 {- | Middleware to add basic authentication protection for a handler.
 
@@ -167,6 +168,7 @@ basicAuth ::
   h (Linked req Request, BasicAuthError e) Response ->
   Middleware h req (BasicAuth m e t : req)
 basicAuth = basicAuth'
+{-# INLINE basicAuth #-}
 
 {- | Similar to `basicAuth` but supports a custom authentication scheme.
 
@@ -183,6 +185,7 @@ basicAuth' ::
   h (Linked req Request, BasicAuthError e) Response ->
   Middleware h req (BasicAuth' Required scheme m e t : req)
 basicAuth' = basicAuthMiddleware
+{-# INLINE basicAuth' #-}
 
 {- | Middleware to add optional basic authentication protection for a handler.
 
@@ -202,6 +205,7 @@ optionalBasicAuth ::
   BasicAuth' Optional "Basic" m e t ->
   Middleware h req (BasicAuth' Optional "Basic" m e t : req)
 optionalBasicAuth = optionalBasicAuth'
+{-# INLINE optionalBasicAuth #-}
 
 {- | Similar to `optionalBasicAuth` but supports a custom authentication
    scheme.
@@ -217,3 +221,4 @@ optionalBasicAuth' ::
   BasicAuth' Optional scheme m e t ->
   Middleware h req (BasicAuth' Optional scheme m e t : req)
 optionalBasicAuth' cfg = basicAuthMiddleware cfg $ arr (absurd . snd)
+{-# INLINE optionalBasicAuth' #-}

--- a/webgear-core/src/WebGear/Core/Trait/Auth/Common.hs
+++ b/webgear-core/src/WebGear/Core/Trait/Auth/Common.hs
@@ -46,6 +46,7 @@ getAuthorizationHeaderTrait ::
 getAuthorizationHeaderTrait = proc request -> do
   result <- getTrait (Header :: Header Optional Lenient "Authorization" (AuthToken scheme)) -< request
   returnA -< either absurd id result
+{-# INLINE getAuthorizationHeaderTrait #-}
 
 -- | The protection space for authentication
 newtype Realm = Realm ByteString
@@ -62,6 +63,7 @@ data AuthToken (scheme :: Symbol) = AuthToken
 instance KnownSymbol scheme => FromHttpApiData (AuthToken scheme) where
   parseUrlPiece = parseHeader . encodeUtf8
 
+  {-# INLINE parseHeader #-}
   parseHeader hdr =
     case break (== ' ') hdr of
       (scm, tok) ->
@@ -98,3 +100,4 @@ respondUnauthorized scheme (Realm realm) = proc _ -> do
     <<< setHeader @"WWW-Authenticate" (respondA HTTP.unauthorized401 "text/plain")
     -<
       (headerVal, "Unauthorized" :: Text)
+{-# INLINE respondUnauthorized #-}

--- a/webgear-core/src/WebGear/Core/Trait/Auth/JWT.hs
+++ b/webgear-core/src/WebGear/Core/Trait/Auth/JWT.hs
@@ -152,6 +152,7 @@ jwtAuth ::
   h (WebGear.Core.Trait.Linked req Request, JWTAuthError e) Response ->
   Middleware h req (JWTAuth m e t : req)
 jwtAuth = jwtAuth' @"Bearer"
+{-# INLINE jwtAuth #-}
 
 {- | Middleware to add optional JWT authentication protection for a
  handler. Expects the JWT to be available via a standard bearer
@@ -176,6 +177,7 @@ optionalJWTAuth ::
   JWTAuth' Optional "Bearer" m e t ->
   Middleware h req (JWTAuth' Optional "Bearer" m e t : req)
 optionalJWTAuth = optionalJWTAuth' @"Bearer"
+{-# INLINE optionalJWTAuth #-}
 
 jwtAuthMiddleware ::
   forall s e t x h m req.
@@ -191,6 +193,7 @@ jwtAuthMiddleware authCfg errorHandler nextHandler =
     case result of
       Left err -> errorHandler -< (request, err)
       Right val -> nextHandler -< val
+{-# INLINE jwtAuthMiddleware #-}
 
 {- | Middleware to add JWT authentication protection for a
  handler. Expects the JWT to be available via an authorization header
@@ -217,6 +220,7 @@ jwtAuth' ::
   h (WebGear.Core.Trait.Linked req Request, JWTAuthError e) Response ->
   Middleware h req (JWTAuth' Required s m e t : req)
 jwtAuth' = jwtAuthMiddleware
+{-# INLINE jwtAuth' #-}
 
 {- | Middleware to add JWT authentication protection for a
  handler. Expects the JWT to be available via an authorization header
@@ -242,3 +246,4 @@ optionalJWTAuth' ::
   JWTAuth' Optional s m e t ->
   Middleware h req (JWTAuth' Optional s m e t : req)
 optionalJWTAuth' cfg = jwtAuthMiddleware cfg $ arr (absurd . snd)
+{-# INLINE optionalJWTAuth' #-}

--- a/webgear-core/src/WebGear/Core/Trait/Body.hs
+++ b/webgear-core/src/WebGear/Core/Trait/Body.hs
@@ -104,6 +104,7 @@ requestBody mediaType errorHandler nextHandler = proc request -> do
   case result of
     Left err -> errorHandler -< (request, err)
     Right t -> nextHandler -< t
+{-# INLINE requestBody #-}
 
 {- | Parse the request body as JSON and convert it to a value of type
    @t@.
@@ -128,6 +129,7 @@ jsonRequestBody' mediaType errorHandler nextHandler = proc request -> do
   case result of
     Left err -> errorHandler -< (request, err)
     Right t -> nextHandler -< t
+{-# INLINE jsonRequestBody' #-}
 
 -- | Same as 'jsonRequestBody'' but with a media type @application/json@.
 jsonRequestBody ::
@@ -137,6 +139,7 @@ jsonRequestBody ::
   h (Linked req Request, Text) Response ->
   Middleware h req (JSONBody t : req)
 jsonRequestBody = jsonRequestBody' (Just "application/json")
+{-# INLINE jsonRequestBody #-}
 
 {- | Set the response body along with a media type.
 
@@ -154,6 +157,7 @@ setBody mediaType prevHandler = proc (body, a) -> do
   r' <- plant (Body (Just mediaType)) -< (r, body)
   let mt = decodeUtf8 $ HTTP.renderHeader mediaType
   plant Header -< (r', mt)
+{-# INLINE setBody #-}
 
 -- | Set the response body without specifying any media type.
 setBodyWithoutContentType ::
@@ -164,6 +168,7 @@ setBodyWithoutContentType ::
 setBodyWithoutContentType prevHandler = proc (body, a) -> do
   r <- prevHandler -< a
   plant (Body Nothing) -< (r, body)
+{-# INLINE setBodyWithoutContentType #-}
 
 {- | Set the response body to a JSON value along with a media type.
 
@@ -181,6 +186,7 @@ setJSONBody' mediaType prevHandler = proc (body, a) -> do
   r' <- plant (JSONBody (Just mediaType)) -< (r, body)
   let mt = decodeUtf8 $ HTTP.renderHeader mediaType
   plant Header -< (r', mt)
+{-# INLINE setJSONBody' #-}
 
 {- | Set the response body to a JSON value.
 
@@ -192,6 +198,7 @@ setJSONBody ::
   h a (Linked ts Response) ->
   h (body, a) (Linked (RequiredHeader "Content-Type" Text : JSONBody body : ts) Response)
 setJSONBody = setJSONBody' "application/json"
+{-# INLINE setJSONBody #-}
 
 {- | Set the response body to a JSON value without specifying any
  media type.
@@ -204,6 +211,7 @@ setJSONBodyWithoutContentType ::
 setJSONBodyWithoutContentType prevHandler = proc (body, a) -> do
   r <- prevHandler -< a
   plant (JSONBody Nothing) -< (r, body)
+{-# INLINE setJSONBodyWithoutContentType #-}
 
 {- | A convenience arrow to generate a response specifying a status and body.
 
@@ -220,6 +228,7 @@ respondA ::
   h body (Linked [RequiredHeader "Content-Type" Text, Body body, Status] Response)
 respondA status mediaType = proc body ->
   setBody mediaType (mkResponse status) -< (body, ())
+{-# INLINE respondA #-}
 
 {- | A convenience arrow to generate a response specifying a status and
    JSON body.
@@ -233,6 +242,7 @@ respondJsonA ::
   HTTP.Status ->
   h body (Linked [RequiredHeader "Content-Type" Text, JSONBody body, Status] Response)
 respondJsonA status = respondJsonA' status "application/json"
+{-# INLINE respondJsonA #-}
 
 {- | A convenience arrow to generate a response specifying a status and
    JSON body.
@@ -250,3 +260,4 @@ respondJsonA' ::
   h body (Linked [RequiredHeader "Content-Type" Text, JSONBody body, Status] Response)
 respondJsonA' status mediaType = proc body ->
   setJSONBody' mediaType (mkResponse status) -< (body, ())
+{-# INLINE respondJsonA' #-}

--- a/webgear-core/src/WebGear/Core/Trait/Header.hs
+++ b/webgear-core/src/WebGear/Core/Trait/Header.hs
@@ -109,6 +109,7 @@ headerHandler errorHandler nextHandler = proc request -> do
   case result of
     Left err -> errorHandler -< (request, err)
     Right val -> nextHandler -< val
+{-# INLINE headerHandler #-}
 
 {- | Extract a header value and convert it to a value of type @val@.
 
@@ -125,6 +126,7 @@ header ::
   h (Linked req Request, Either HeaderNotFound HeaderParseError) Response ->
   Middleware h req (Header Required Strict name val : req)
 header = headerHandler
+{-# INLINE header #-}
 
 {- | Extract an optional header value and convert it to a value of type
  @val@.
@@ -143,6 +145,7 @@ optionalHeader ::
   h (Linked req Request, HeaderParseError) Response ->
   Middleware h req (Header Optional Strict name val : req)
 optionalHeader = headerHandler
+{-# INLINE optionalHeader #-}
 
 {- | Extract a header value and convert it to a value of type @val@.
 
@@ -161,6 +164,7 @@ lenientHeader ::
   h (Linked req Request, HeaderNotFound) Response ->
   Middleware h req (Header Required Lenient name val : req)
 lenientHeader = headerHandler
+{-# INLINE lenientHeader #-}
 
 {- | Extract a header value and convert it to a value of type @val@.
 
@@ -177,6 +181,7 @@ optionalLenientHeader ::
   (Get h (Header Optional Lenient name val) Request, ArrowChoice h) =>
   Middleware h req (Header Optional Lenient name val : req)
 optionalLenientHeader = headerHandler $ arr (absurd . snd)
+{-# INLINE optionalLenientHeader #-}
 
 instance Trait (Header Required Strict name val) Response where
   type Attribute (Header Required Strict name val) Response = val
@@ -198,6 +203,7 @@ setHeader ::
 setHeader prevHandler = proc (val, a) -> do
   r <- prevHandler -< a
   plant Header -< (r, val)
+{-# INLINE setHeader #-}
 
 {- | Set an optional header value in a response.
 
@@ -217,3 +223,4 @@ setOptionalHeader ::
 setOptionalHeader prevHandler = proc (val, a) -> do
   r <- prevHandler -< a
   plant Header -< (r, val)
+{-# INLINE setOptionalHeader #-}

--- a/webgear-core/src/WebGear/Core/Trait/Method.hs
+++ b/webgear-core/src/WebGear/Core/Trait/Method.hs
@@ -45,3 +45,4 @@ method ::
   HTTP.StdMethod ->
   Middleware h req (Method : req)
 method m nextHandler = probe (Method m) >>> routeMismatch ||| nextHandler
+{-# INLINE method #-}

--- a/webgear-core/src/WebGear/Core/Trait/Path.hs
+++ b/webgear-core/src/WebGear/Core/Trait/Path.hs
@@ -85,6 +85,7 @@ path ::
   Text ->
   Middleware h req (Path : req)
 path s nextHandler = probe (Path s) >>> routeMismatch ||| nextHandler
+{-# INLINE path #-}
 
 {- | A middleware that captures a path variable from a single path
  component.
@@ -103,12 +104,14 @@ pathVar ::
   (Get h (PathVar tag val) Request, ArrowChoice h, ArrowError RouteMismatch h) =>
   Middleware h req (PathVar tag val : req)
 pathVar nextHandler = probe PathVar >>> routeMismatch ||| nextHandler
+{-# INLINE pathVar #-}
 
 -- | A middleware that verifies that end of path is reached.
 pathEnd ::
   (Get h PathEnd Request, ArrowChoice h, ArrowError RouteMismatch h) =>
   Middleware h req (PathEnd : req)
 pathEnd nextHandler = probe PathEnd >>> routeMismatch ||| nextHandler
+{-# INLINE pathEnd #-}
 
 {- | Produces middleware(s) to match an optional HTTP method and some
  path components.

--- a/webgear-core/src/WebGear/Core/Trait/QueryParam.hs
+++ b/webgear-core/src/WebGear/Core/Trait/QueryParam.hs
@@ -101,6 +101,7 @@ queryParamHandler errorHandler nextHandler = proc request -> do
   case result of
     Left err -> errorHandler -< (request, err)
     Right val -> nextHandler -< val
+{-# INLINE queryParamHandler #-}
 
 {- | Extract a query parameter and convert it to a value of type
  @val@.
@@ -117,6 +118,7 @@ queryParam ::
   h (Linked req Request, Either ParamNotFound ParamParseError) Response ->
   Middleware h req (QueryParam Required Strict name val : req)
 queryParam = queryParamHandler
+{-# INLINE queryParam #-}
 
 {- | Extract an optional query parameter and convert it to a value of
  type @val@.
@@ -134,6 +136,7 @@ optionalQueryParam ::
   h (Linked req Request, ParamParseError) Response ->
   Middleware h req (QueryParam Optional Strict name val : req)
 optionalQueryParam = queryParamHandler
+{-# INLINE optionalQueryParam #-}
 
 {- | Extract a query parameter and convert it to a value of type @val@.
 
@@ -151,6 +154,7 @@ lenientQueryParam ::
   h (Linked req Request, ParamNotFound) Response ->
   Middleware h req (QueryParam Required Lenient name val : req)
 lenientQueryParam = queryParamHandler
+{-# INLINE lenientQueryParam #-}
 
 {- | Extract a query parameter and convert it to a value of type @val@.
 
@@ -167,3 +171,4 @@ optionalLenientQueryParam ::
   (Get h (QueryParam Optional Lenient name val) Request, ArrowChoice h) =>
   Middleware h req (QueryParam Optional Lenient name val : req)
 optionalLenientQueryParam = queryParamHandler $ arr (absurd . snd)
+{-# INLINE optionalLenientQueryParam #-}

--- a/webgear-core/src/WebGear/Core/Trait/Status.hs
+++ b/webgear-core/src/WebGear/Core/Trait/Status.hs
@@ -67,187 +67,234 @@ mkResponse :: Set h Status Response => HTTP.Status -> h () (Linked '[Status] Res
 mkResponse status = proc () -> do
   let response = linkzero $ Response status [] Nothing
   plant (Status status) -< (response, status)
+{-# INLINE mkResponse #-}
 
 -- | Continue 100 response
 continue100 :: Set h Status Response => h () (Linked '[Status] Response)
 continue100 = mkResponse HTTP.continue100
+{-# INLINE continue100 #-}
 
 -- | Switching Protocols 101 response
 switchingProtocols101 :: Set h Status Response => h () (Linked '[Status] Response)
 switchingProtocols101 = mkResponse HTTP.switchingProtocols101
+{-# INLINE switchingProtocols101 #-}
 
 -- | OK 200 response
 ok200 :: Set h Status Response => h () (Linked '[Status] Response)
 ok200 = mkResponse HTTP.ok200
+{-# INLINE ok200 #-}
 
 -- | Created 201 response
 created201 :: Set h Status Response => h () (Linked '[Status] Response)
 created201 = mkResponse HTTP.created201
+{-# INLINE created201 #-}
 
 -- | Accepted 202 response
 accepted202 :: Set h Status Response => h () (Linked '[Status] Response)
 accepted202 = mkResponse HTTP.accepted202
+{-# INLINE accepted202 #-}
 
 -- | Non-Authoritative 203 response
 nonAuthoritative203 :: Set h Status Response => h () (Linked '[Status] Response)
 nonAuthoritative203 = mkResponse HTTP.nonAuthoritative203
+{-# INLINE nonAuthoritative203 #-}
 
 -- | No Content 204 response
 noContent204 :: Set h Status Response => h () (Linked '[Status] Response)
 noContent204 = mkResponse HTTP.noContent204
+{-# INLINE noContent204 #-}
 
 -- | Reset Content 205 response
 resetContent205 :: Set h Status Response => h () (Linked '[Status] Response)
 resetContent205 = mkResponse HTTP.resetContent205
+{-# INLINE resetContent205 #-}
 
 -- | Partial Content 206 response
 partialContent206 :: Set h Status Response => h () (Linked '[Status] Response)
 partialContent206 = mkResponse HTTP.partialContent206
+{-# INLINE partialContent206 #-}
 
 -- | Multiple Choices 300 response
 multipleChoices300 :: Set h Status Response => h () (Linked '[Status] Response)
 multipleChoices300 = mkResponse HTTP.multipleChoices300
+{-# INLINE multipleChoices300 #-}
 
 -- | Moved Permanently 301 response
 movedPermanently301 :: Set h Status Response => h () (Linked '[Status] Response)
 movedPermanently301 = mkResponse HTTP.movedPermanently301
+{-# INLINE movedPermanently301 #-}
 
 -- | Found 302 response
 found302 :: Set h Status Response => h () (Linked '[Status] Response)
 found302 = mkResponse HTTP.found302
+{-# INLINE found302 #-}
 
 -- | See Other 303 response
 seeOther303 :: Set h Status Response => h () (Linked '[Status] Response)
 seeOther303 = mkResponse HTTP.seeOther303
+{-# INLINE seeOther303 #-}
 
 -- | Not Modified 304 response
 notModified304 :: Set h Status Response => h () (Linked '[Status] Response)
 notModified304 = mkResponse HTTP.notModified304
+{-# INLINE notModified304 #-}
 
 -- | Temporary Redirect 307 response
 temporaryRedirect307 :: Set h Status Response => h () (Linked '[Status] Response)
 temporaryRedirect307 = mkResponse HTTP.temporaryRedirect307
+{-# INLINE temporaryRedirect307 #-}
 
 -- | Permanent Redirect 308 response
 permanentRedirect308 :: Set h Status Response => h () (Linked '[Status] Response)
 permanentRedirect308 = mkResponse HTTP.permanentRedirect308
+{-# INLINE permanentRedirect308 #-}
 
 -- | Bad Request 400 response
 badRequest400 :: Set h Status Response => h () (Linked '[Status] Response)
 badRequest400 = mkResponse HTTP.badRequest400
+{-# INLINE badRequest400 #-}
 
 -- | Unauthorized 401 response
 unauthorized401 :: Set h Status Response => h () (Linked '[Status] Response)
 unauthorized401 = mkResponse HTTP.unauthorized401
+{-# INLINE unauthorized401 #-}
 
 -- | Payment Required 402 response
 paymentRequired402 :: Set h Status Response => h () (Linked '[Status] Response)
 paymentRequired402 = mkResponse HTTP.paymentRequired402
+{-# INLINE paymentRequired402 #-}
 
 -- | Forbidden 403 response
 forbidden403 :: Set h Status Response => h () (Linked '[Status] Response)
 forbidden403 = mkResponse HTTP.forbidden403
+{-# INLINE forbidden403 #-}
 
 -- | Not Found 404 response
 notFound404 :: Set h Status Response => h () (Linked '[Status] Response)
 notFound404 = mkResponse HTTP.notFound404
+{-# INLINE notFound404 #-}
 
 -- | Method Not Allowed 405 response
 methodNotAllowed405 :: Set h Status Response => h () (Linked '[Status] Response)
 methodNotAllowed405 = mkResponse HTTP.methodNotAllowed405
+{-# INLINE methodNotAllowed405 #-}
 
 -- | Not Acceptable 406 response
 notAcceptable406 :: Set h Status Response => h () (Linked '[Status] Response)
 notAcceptable406 = mkResponse HTTP.notAcceptable406
+{-# INLINE notAcceptable406 #-}
 
 -- | Proxy Authentication Required 407 response
 proxyAuthenticationRequired407 :: Set h Status Response => h () (Linked '[Status] Response)
 proxyAuthenticationRequired407 = mkResponse HTTP.proxyAuthenticationRequired407
+{-# INLINE proxyAuthenticationRequired407 #-}
 
 -- | Request Timeout 408 response
 requestTimeout408 :: Set h Status Response => h () (Linked '[Status] Response)
 requestTimeout408 = mkResponse HTTP.requestTimeout408
+{-# INLINE requestTimeout408 #-}
 
 -- | Conflict 409 response
 conflict409 :: Set h Status Response => h () (Linked '[Status] Response)
 conflict409 = mkResponse HTTP.conflict409
+{-# INLINE conflict409 #-}
 
 -- | Gone 410 response
 gone410 :: Set h Status Response => h () (Linked '[Status] Response)
 gone410 = mkResponse HTTP.gone410
+{-# INLINE gone410 #-}
 
 -- | Length Required 411 response
 lengthRequired411 :: Set h Status Response => h () (Linked '[Status] Response)
 lengthRequired411 = mkResponse HTTP.lengthRequired411
+{-# INLINE lengthRequired411 #-}
 
 -- | Precondition Failed 412 response
 preconditionFailed412 :: Set h Status Response => h () (Linked '[Status] Response)
 preconditionFailed412 = mkResponse HTTP.preconditionFailed412
+{-# INLINE preconditionFailed412 #-}
 
 -- | Request Entity Too Large 413 response
 requestEntityTooLarge413 :: Set h Status Response => h () (Linked '[Status] Response)
 requestEntityTooLarge413 = mkResponse HTTP.requestEntityTooLarge413
+{-# INLINE requestEntityTooLarge413 #-}
 
 -- | Request URI Too Long 414 response
 requestURITooLong414 :: Set h Status Response => h () (Linked '[Status] Response)
 requestURITooLong414 = mkResponse HTTP.requestURITooLong414
+{-# INLINE requestURITooLong414 #-}
 
 -- | Unsupported Media Type 415 response
 unsupportedMediaType415 :: Set h Status Response => h () (Linked '[Status] Response)
 unsupportedMediaType415 = mkResponse HTTP.unsupportedMediaType415
+{-# INLINE unsupportedMediaType415 #-}
 
 -- | Requested Range Not Satisfiable 416 response
 requestedRangeNotSatisfiable416 :: Set h Status Response => h () (Linked '[Status] Response)
 requestedRangeNotSatisfiable416 = mkResponse HTTP.requestedRangeNotSatisfiable416
+{-# INLINE requestedRangeNotSatisfiable416 #-}
 
 -- | Expectation Failed 417 response
 expectationFailed417 :: Set h Status Response => h () (Linked '[Status] Response)
 expectationFailed417 = mkResponse HTTP.expectationFailed417
+{-# INLINE expectationFailed417 #-}
 
 -- | I'm A Teapot 418 response
 imATeapot418 :: Set h Status Response => h () (Linked '[Status] Response)
 imATeapot418 = mkResponse HTTP.imATeapot418
+{-# INLINE imATeapot418 #-}
 
 -- | Unprocessable Entity 422 response
 unprocessableEntity422 :: Set h Status Response => h () (Linked '[Status] Response)
 unprocessableEntity422 = mkResponse HTTP.unprocessableEntity422
+{-# INLINE unprocessableEntity422 #-}
 
 -- | Precondition Required 428 response
 preconditionRequired428 :: Set h Status Response => h () (Linked '[Status] Response)
 preconditionRequired428 = mkResponse HTTP.preconditionRequired428
+{-# INLINE preconditionRequired428 #-}
 
 -- | Too Many Requests 429 response
 tooManyRequests429 :: Set h Status Response => h () (Linked '[Status] Response)
 tooManyRequests429 = mkResponse HTTP.tooManyRequests429
+{-# INLINE tooManyRequests429 #-}
 
 -- | Request Header Fields Too Large 431 response
 requestHeaderFieldsTooLarge431 :: Set h Status Response => h () (Linked '[Status] Response)
 requestHeaderFieldsTooLarge431 = mkResponse HTTP.requestHeaderFieldsTooLarge431
+{-# INLINE requestHeaderFieldsTooLarge431 #-}
 
 -- | Internal Server Error 500 response
 internalServerError500 :: Set h Status Response => h () (Linked '[Status] Response)
 internalServerError500 = mkResponse HTTP.internalServerError500
+{-# INLINE internalServerError500 #-}
 
 -- | Not Implemented 501 response
 notImplemented501 :: Set h Status Response => h () (Linked '[Status] Response)
 notImplemented501 = mkResponse HTTP.notImplemented501
+{-# INLINE notImplemented501 #-}
 
 -- | Bad Gateway 502 response
 badGateway502 :: Set h Status Response => h () (Linked '[Status] Response)
 badGateway502 = mkResponse HTTP.badGateway502
+{-# INLINE badGateway502 #-}
 
 -- | Service Unavailable 503 response
 serviceUnavailable503 :: Set h Status Response => h () (Linked '[Status] Response)
 serviceUnavailable503 = mkResponse HTTP.serviceUnavailable503
+{-# INLINE serviceUnavailable503 #-}
 
 -- | Gateway Timeout 504 response
 gatewayTimeout504 :: Set h Status Response => h () (Linked '[Status] Response)
 gatewayTimeout504 = mkResponse HTTP.gatewayTimeout504
+{-# INLINE gatewayTimeout504 #-}
 
 -- | HTTP Version Not Supported 505 response
 httpVersionNotSupported505 :: Set h Status Response => h () (Linked '[Status] Response)
 httpVersionNotSupported505 = mkResponse HTTP.httpVersionNotSupported505
+{-# INLINE httpVersionNotSupported505 #-}
 
 -- | Network Authentication Required 511 response
 networkAuthenticationRequired511 :: Set h Status Response => h () (Linked '[Status] Response)
 networkAuthenticationRequired511 = mkResponse HTTP.networkAuthenticationRequired511
+{-# INLINE networkAuthenticationRequired511 #-}

--- a/webgear-openapi/src/WebGear/OpenApi/Handler.hs
+++ b/webgear-openapi/src/WebGear/OpenApi/Handler.hs
@@ -128,30 +128,30 @@ instance ArrowChoice (OpenApiHandler m) where
   OpenApiHandler doc1 ||| OpenApiHandler doc2 = OpenApiHandler $ BinaryNode doc1 doc2
 
 instance ArrowError RouteMismatch (OpenApiHandler m) where
-  {-# INLINEABLE raise #-}
+  {-# INLINE raise #-}
   raise = OpenApiHandler{openApiDoc = NullNode}
 
-  {-# INLINEABLE handle #-}
+  {-# INLINE handle #-}
   OpenApiHandler doc1 `handle` OpenApiHandler doc2 = OpenApiHandler $ BinaryNode doc1 doc2
 
-  {-# INLINEABLE tryInUnless #-}
+  {-# INLINE tryInUnless #-}
   tryInUnless (OpenApiHandler doc1) (OpenApiHandler doc2) (OpenApiHandler doc3) =
     OpenApiHandler $ BinaryNode (BinaryNode doc1 doc2) doc3
 
 instance Monad m => Handler (OpenApiHandler m) m where
-  {-# INLINEABLE arrM #-}
+  {-# INLINE arrM #-}
   arrM :: (a -> m b) -> OpenApiHandler m a b
   arrM _ = OpenApiHandler{openApiDoc = NullNode}
 
-  {-# INLINEABLE consumeRoute #-}
+  {-# INLINE consumeRoute #-}
   consumeRoute :: OpenApiHandler m RoutePath a -> OpenApiHandler m () a
   consumeRoute (OpenApiHandler doc) = OpenApiHandler doc
 
-  {-# INLINEABLE setDescription #-}
+  {-# INLINE setDescription #-}
   setDescription :: Description -> OpenApiHandler m a a
   setDescription = OpenApiHandler . singletonNode . DocDescription
 
-  {-# INLINEABLE setSummary #-}
+  {-# INLINE setSummary #-}
   setSummary :: Summary -> OpenApiHandler m a a
   setSummary = OpenApiHandler . singletonNode . DocSummary
 

--- a/webgear-openapi/src/WebGear/OpenApi/Trait/Auth/Basic.hs
+++ b/webgear-openapi/src/WebGear/OpenApi/Trait/Auth/Basic.hs
@@ -13,7 +13,7 @@ import WebGear.Core.Trait.Auth.Basic (BasicAuth' (..))
 import WebGear.OpenApi.Handler (DocNode (DocSecurityScheme), OpenApiHandler (..), singletonNode)
 
 instance (TraitAbsence (BasicAuth' x scheme m e a) Request, KnownSymbol scheme) => Get (OpenApiHandler m) (BasicAuth' x scheme m e a) Request where
-  {-# INLINEABLE getTrait #-}
+  {-# INLINE getTrait #-}
   getTrait ::
     BasicAuth' x scheme m e a ->
     OpenApiHandler m (Linked ts Request) (Either (Absence (BasicAuth' x scheme m e a) Request) (Attribute (BasicAuth' x scheme m e a) Request))

--- a/webgear-openapi/src/WebGear/OpenApi/Trait/Auth/JWT.hs
+++ b/webgear-openapi/src/WebGear/OpenApi/Trait/Auth/JWT.hs
@@ -16,7 +16,7 @@ instance
   (TraitAbsence (JWTAuth' x scheme m e a) Request, KnownSymbol scheme) =>
   Get (OpenApiHandler m) (JWTAuth' x scheme m e a) Request
   where
-  {-# INLINEABLE getTrait #-}
+  {-# INLINE getTrait #-}
   getTrait ::
     JWTAuth' x scheme m e a ->
     OpenApiHandler m (Linked ts Request) (Either (Absence (JWTAuth' x scheme m e a) Request) (Attribute (JWTAuth' x scheme m e a) Request))

--- a/webgear-openapi/src/WebGear/OpenApi/Trait/Body.hs
+++ b/webgear-openapi/src/WebGear/OpenApi/Trait/Body.hs
@@ -20,7 +20,7 @@ import WebGear.OpenApi.Handler (
  )
 
 instance ToSchema val => Get (OpenApiHandler m) (Body val) Request where
-  {-# INLINEABLE getTrait #-}
+  {-# INLINE getTrait #-}
   getTrait :: Body val -> OpenApiHandler m (Linked ts Request) (Either Text val)
   getTrait (Body maybeMediaType) =
     let mediaType = fromMaybe "*/*" maybeMediaType
@@ -31,7 +31,7 @@ instance ToSchema val => Get (OpenApiHandler m) (Body val) Request where
      in OpenApiHandler $ singletonNode (DocRequestBody defs body)
 
 instance ToSchema val => Set (OpenApiHandler m) (Body val) Response where
-  {-# INLINEABLE setTrait #-}
+  {-# INLINE setTrait #-}
   setTrait ::
     Body val ->
     (Linked ts Response -> Response -> val -> Linked (Body val : ts) Response) ->
@@ -43,12 +43,12 @@ instance ToSchema val => Set (OpenApiHandler m) (Body val) Response where
      in OpenApiHandler $ singletonNode (DocResponseBody defs mediaType body)
 
 instance ToSchema val => Get (OpenApiHandler m) (JSONBody val) Request where
-  {-# INLINEABLE getTrait #-}
+  {-# INLINE getTrait #-}
   getTrait :: JSONBody val -> OpenApiHandler m (Linked ts Request) (Either Text val)
   getTrait (JSONBody maybeMediaType) = getTrait (Body @val maybeMediaType)
 
 instance ToSchema val => Set (OpenApiHandler m) (JSONBody val) Response where
-  {-# INLINEABLE setTrait #-}
+  {-# INLINE setTrait #-}
   setTrait ::
     JSONBody val ->
     (Linked ts Response -> Response -> t -> Linked (JSONBody val : ts) Response) ->

--- a/webgear-openapi/src/WebGear/OpenApi/Trait/Header.hs
+++ b/webgear-openapi/src/WebGear/OpenApi/Trait/Header.hs
@@ -31,17 +31,17 @@ mkParam _ _ isRequired =
     & schema ?~ Inline (toSchema $ Proxy @val)
 
 instance (KnownSymbol name, ToSchema val, TraitAbsence (WG.Header Required ps name val) Request) => Get (OpenApiHandler m) (WG.Header Required ps name val) Request where
-  {-# INLINEABLE getTrait #-}
+  {-# INLINE getTrait #-}
   getTrait WG.Header =
     OpenApiHandler $ singletonNode (DocRequestHeader $ mkParam (Proxy @name) (Proxy @val) True)
 
 instance (KnownSymbol name, ToSchema val, TraitAbsence (WG.Header Optional ps name val) Request) => Get (OpenApiHandler m) (WG.Header Optional ps name val) Request where
-  {-# INLINEABLE getTrait #-}
+  {-# INLINE getTrait #-}
   getTrait WG.Header =
     OpenApiHandler $ singletonNode (DocRequestHeader $ mkParam (Proxy @name) (Proxy @val) False)
 
 instance (KnownSymbol name, ToSchema val, Trait (WG.Header Required ps name val) Response) => Set (OpenApiHandler m) (WG.Header Required ps name val) Response where
-  {-# INLINEABLE setTrait #-}
+  {-# INLINE setTrait #-}
   setTrait WG.Header _ =
     let headerName = fromString $ symbolVal $ Proxy @name
         header =
@@ -53,7 +53,7 @@ instance (KnownSymbol name, ToSchema val, Trait (WG.Header Required ps name val)
           else OpenApiHandler $ singletonNode (DocResponseHeader headerName header)
 
 instance (KnownSymbol name, ToSchema val, Trait (WG.Header Optional ps name val) Response) => Set (OpenApiHandler m) (WG.Header Optional ps name val) Response where
-  {-# INLINEABLE setTrait #-}
+  {-# INLINE setTrait #-}
   setTrait WG.Header _ =
     let headerName = fromString $ symbolVal $ Proxy @name
         header =

--- a/webgear-openapi/src/WebGear/OpenApi/Trait/Method.hs
+++ b/webgear-openapi/src/WebGear/OpenApi/Trait/Method.hs
@@ -9,5 +9,5 @@ import WebGear.Core.Trait.Method (Method (..))
 import WebGear.OpenApi.Handler (DocNode (DocMethod), OpenApiHandler (OpenApiHandler), singletonNode)
 
 instance Get (OpenApiHandler m) Method Request where
-  {-# INLINEABLE getTrait #-}
+  {-# INLINE getTrait #-}
   getTrait (Method method) = OpenApiHandler $ singletonNode (DocMethod method)

--- a/webgear-openapi/src/WebGear/OpenApi/Trait/Path.hs
+++ b/webgear-openapi/src/WebGear/OpenApi/Trait/Path.hs
@@ -17,12 +17,12 @@ import WebGear.OpenApi.Handler (
  )
 
 instance Get (OpenApiHandler m) Path Request where
-  {-# INLINEABLE getTrait #-}
+  {-# INLINE getTrait #-}
   getTrait :: Path -> OpenApiHandler m (Linked ts Request) (Either () ())
   getTrait (Path p) = OpenApiHandler $ singletonNode (DocPathElem p)
 
 instance (KnownSymbol tag, ToSchema val) => Get (OpenApiHandler m) (PathVar tag val) Request where
-  {-# INLINEABLE getTrait #-}
+  {-# INLINE getTrait #-}
   getTrait :: PathVar tag val -> OpenApiHandler m (Linked ts Request) (Either PathVarError val)
   getTrait PathVar =
     let param =
@@ -35,6 +35,6 @@ instance (KnownSymbol tag, ToSchema val) => Get (OpenApiHandler m) (PathVar tag 
      in OpenApiHandler $ singletonNode (DocPathVar param)
 
 instance Get (OpenApiHandler m) PathEnd Request where
-  {-# INLINEABLE getTrait #-}
+  {-# INLINE getTrait #-}
   getTrait :: PathEnd -> OpenApiHandler m (Linked ts Request) (Either () ())
   getTrait PathEnd = OpenApiHandler $ singletonNode (DocPathElem "/")

--- a/webgear-openapi/src/WebGear/OpenApi/Trait/QueryParam.hs
+++ b/webgear-openapi/src/WebGear/OpenApi/Trait/QueryParam.hs
@@ -20,7 +20,7 @@ import WebGear.Core.Trait.QueryParam (QueryParam (..))
 import WebGear.OpenApi.Handler (DocNode (DocQueryParam), OpenApiHandler (..), singletonNode)
 
 instance (KnownSymbol name, ToSchema val, TraitAbsence (QueryParam Required ps name val) Request) => Get (OpenApiHandler m) (QueryParam Required ps name val) Request where
-  {-# INLINEABLE getTrait #-}
+  {-# INLINE getTrait #-}
   getTrait _ =
     let param =
           (mempty :: Param)
@@ -32,7 +32,7 @@ instance (KnownSymbol name, ToSchema val, TraitAbsence (QueryParam Required ps n
      in OpenApiHandler $ singletonNode (DocQueryParam param)
 
 instance (KnownSymbol name, ToSchema val, TraitAbsence (QueryParam Optional ps name val) Request) => Get (OpenApiHandler m) (QueryParam Optional ps name val) Request where
-  {-# INLINEABLE getTrait #-}
+  {-# INLINE getTrait #-}
   getTrait _ =
     let param =
           (mempty :: Param)

--- a/webgear-openapi/src/WebGear/OpenApi/Trait/Status.hs
+++ b/webgear-openapi/src/WebGear/OpenApi/Trait/Status.hs
@@ -10,7 +10,7 @@ import WebGear.Core.Trait.Status (Status (..))
 import WebGear.OpenApi.Handler (DocNode (DocStatus), OpenApiHandler (..), singletonNode)
 
 instance Set (OpenApiHandler m) Status Response where
-  {-# INLINEABLE setTrait #-}
+  {-# INLINE setTrait #-}
   setTrait ::
     Status ->
     (Linked ts Response -> Response -> HTTP.Status -> Linked (Status : ts) Response) ->

--- a/webgear-server/src/WebGear/Server/Handler.hs
+++ b/webgear-server/src/WebGear/Server/Handler.hs
@@ -135,6 +135,7 @@ runServerHandler ::
   -- | The result of the arrow
   m (Either RouteMismatch b)
 runServerHandler (ServerHandler h) path a = fst <$> h (a, path)
+{-# INLINE runServerHandler #-}
 
 -- | Convert a ServerHandler to a WAI application
 toApplication :: ServerHandler IO (Linked '[] Request) Response -> Wai.Application
@@ -153,6 +154,10 @@ toApplication h rqt cont =
 
     addServerHeader :: Response -> Response
     addServerHeader resp@Response{..} = resp{responseHeaders = responseHeaders <> webGearServerHeader}
+
+    webGearServerHeader :: HM.HashMap HTTP.HeaderName ByteString
+    webGearServerHeader = HM.singleton HTTP.hServer (fromString $ "WebGear/" ++ showVersion version)
+{-# INLINE toApplication #-}
 
 {- | Transform a `ServerHandler` running in one monad to another monad.
 
@@ -178,6 +183,4 @@ transform ::
   ServerHandler n a b
 transform f (ServerHandler g) =
   ServerHandler $ f . g
-
-webGearServerHeader :: HM.HashMap HTTP.HeaderName ByteString
-webGearServerHeader = HM.singleton HTTP.hServer (fromString $ "WebGear/" ++ showVersion version)
+{-# INLINE transform #-}

--- a/webgear-server/src/WebGear/Server/Handler.hs
+++ b/webgear-server/src/WebGear/Server/Handler.hs
@@ -34,10 +34,10 @@ import WebGear.Core.Trait (Linked, linkzero)
 newtype ServerHandler m a b = ServerHandler {unServerHandler :: (a, RoutePath) -> m (Either RouteMismatch b, RoutePath)}
 
 instance Monad m => Cat.Category (ServerHandler m) where
-  {-# INLINEABLE id #-}
+  {-# INLINE id #-}
   id = ServerHandler $ \(a, s) -> pure (Right a, s)
 
-  {-# INLINEABLE (.) #-}
+  {-# INLINE (.) #-}
   ServerHandler f . ServerHandler g = ServerHandler $ \(a, s) ->
     g (a, s) >>= \case
       (Left e, s') -> pure (Left e, s')
@@ -46,31 +46,31 @@ instance Monad m => Cat.Category (ServerHandler m) where
 instance Monad m => Arrow (ServerHandler m) where
   arr f = ServerHandler (\(a, s) -> pure (Right (f a), s))
 
-  {-# INLINEABLE first #-}
+  {-# INLINE first #-}
   first (ServerHandler f) = ServerHandler $ \((a, c), s) ->
     f (a, s) >>= \case
       (Left e, s') -> pure (Left e, s')
       (Right b, s') -> pure (Right (b, c), s')
 
-  {-# INLINEABLE second #-}
+  {-# INLINE second #-}
   second (ServerHandler f) = ServerHandler $ \((c, a), s) ->
     f (a, s) >>= \case
       (Left e, s') -> pure (Left e, s')
       (Right b, s') -> pure (Right (c, b), s')
 
 instance Monad m => ArrowZero (ServerHandler m) where
-  {-# INLINEABLE zeroArrow #-}
+  {-# INLINE zeroArrow #-}
   zeroArrow = ServerHandler (\(_a, s) -> pure (Left mempty, s))
 
 instance Monad m => ArrowPlus (ServerHandler m) where
-  {-# INLINEABLE (<+>) #-}
+  {-# INLINE (<+>) #-}
   ServerHandler f <+> ServerHandler g = ServerHandler $ \(a, s) ->
     f (a, s) >>= \case
       (Left _e, _s') -> g (a, s)
       (Right b, s') -> pure (Right b, s')
 
 instance Monad m => ArrowChoice (ServerHandler m) where
-  {-# INLINEABLE left #-}
+  {-# INLINE left #-}
   left (ServerHandler f) = ServerHandler $ \(bd, s) ->
     case bd of
       Right d -> pure (Right (Right d), s)
@@ -79,7 +79,7 @@ instance Monad m => ArrowChoice (ServerHandler m) where
           (Left e, s') -> pure (Left e, s')
           (Right c, s') -> pure (Right (Left c), s')
 
-  {-# INLINEABLE right #-}
+  {-# INLINE right #-}
   right (ServerHandler f) = ServerHandler $ \(db, s) ->
     case db of
       Left d -> pure (Right (Left d), s)
@@ -89,16 +89,16 @@ instance Monad m => ArrowChoice (ServerHandler m) where
           (Right c, s') -> pure (Right (Right c), s')
 
 instance Monad m => ArrowError RouteMismatch (ServerHandler m) where
-  {-# INLINEABLE raise #-}
+  {-# INLINE raise #-}
   raise = ServerHandler $ \(e, s) -> pure (Left e, s)
 
-  {-# INLINEABLE handle #-}
+  {-# INLINE handle #-}
   (ServerHandler action) `handle` (ServerHandler errHandler) = ServerHandler $ \(a, s) ->
     action (a, s) >>= \case
       (Left e, s') -> errHandler ((a, e), s')
       (Right b, s') -> pure (Right b, s')
 
-  {-# INLINEABLE tryInUnless #-}
+  {-# INLINE tryInUnless #-}
   tryInUnless (ServerHandler action) (ServerHandler resHandler) (ServerHandler errHandler) =
     ServerHandler $ \(a, s) ->
       action (a, s) >>= \case
@@ -106,20 +106,20 @@ instance Monad m => ArrowError RouteMismatch (ServerHandler m) where
         (Right b, s') -> resHandler ((a, b), s')
 
 instance Monad m => Handler (ServerHandler m) m where
-  {-# INLINEABLE arrM #-}
+  {-# INLINE arrM #-}
   arrM :: (a -> m b) -> ServerHandler m a b
   arrM f = ServerHandler $ \(a, s) -> f a >>= \b -> pure (Right b, s)
 
-  {-# INLINEABLE consumeRoute #-}
+  {-# INLINE consumeRoute #-}
   consumeRoute :: ServerHandler m RoutePath a -> ServerHandler m () a
   consumeRoute (ServerHandler h) = ServerHandler $
     \((), path) -> h (path, RoutePath [])
 
-  {-# INLINEABLE setDescription #-}
+  {-# INLINE setDescription #-}
   setDescription :: Description -> ServerHandler m a a
   setDescription _ = Cat.id
 
-  {-# INLINEABLE setSummary #-}
+  {-# INLINE setSummary #-}
   setSummary :: Summary -> ServerHandler m a a
   setSummary _ = Cat.id
 

--- a/webgear-server/src/WebGear/Server/Trait/Auth/Basic.hs
+++ b/webgear-server/src/WebGear/Server/Trait/Auth/Basic.hs
@@ -33,7 +33,7 @@ instance
   ) =>
   Get (ServerHandler m) (BasicAuth' Required scheme m e a) Request
   where
-  {-# INLINEABLE getTrait #-}
+  {-# INLINE getTrait #-}
   getTrait ::
     BasicAuth' Required scheme m e a ->
     ServerHandler m (Linked ts Request) (Either (BasicAuthError e) a)
@@ -64,7 +64,7 @@ instance
   ) =>
   Get (ServerHandler m) (BasicAuth' Optional scheme m e a) Request
   where
-  {-# INLINEABLE getTrait #-}
+  {-# INLINE getTrait #-}
   getTrait ::
     BasicAuth' Optional scheme m e a ->
     ServerHandler m (Linked ts Request) (Either Void (Either (BasicAuthError e) a))

--- a/webgear-server/src/WebGear/Server/Trait/Auth/JWT.hs
+++ b/webgear-server/src/WebGear/Server/Trait/Auth/JWT.hs
@@ -23,7 +23,7 @@ import WebGear.Core.Trait.Auth.JWT (JWTAuth' (..), JWTAuthError (..))
 import WebGear.Server.Handler (ServerHandler)
 
 instance (MonadTime m, Get (ServerHandler m) (AuthorizationHeader scheme) Request) => Get (ServerHandler m) (JWTAuth' Required scheme m e a) Request where
-  {-# INLINEABLE getTrait #-}
+  {-# INLINE getTrait #-}
   getTrait ::
     JWTAuth' Required scheme m e a ->
     ServerHandler m (Linked ts Request) (Either (JWTAuthError e) a)
@@ -46,7 +46,7 @@ instance (MonadTime m, Get (ServerHandler m) (AuthorizationHeader scheme) Reques
         lift (toJWTAttribute claims) >>= either (throwError . JWTAuthAttributeError) pure
 
 instance (MonadTime m, Get (ServerHandler m) (AuthorizationHeader scheme) Request) => Get (ServerHandler m) (JWTAuth' Optional scheme m e a) Request where
-  {-# INLINEABLE getTrait #-}
+  {-# INLINE getTrait #-}
   getTrait ::
     JWTAuth' Optional scheme m e a ->
     ServerHandler m (Linked ts Request) (Either Void (Either (JWTAuthError e) a))

--- a/webgear-server/src/WebGear/Server/Trait/Body.hs
+++ b/webgear-server/src/WebGear/Server/Trait/Body.hs
@@ -19,7 +19,7 @@ import WebGear.Core.Trait.Body (Body (..), JSONBody (..))
 import WebGear.Server.Handler (ServerHandler)
 
 instance (MonadIO m, FromByteString val) => Get (ServerHandler m) (Body val) Request where
-  {-# INLINEABLE getTrait #-}
+  {-# INLINE getTrait #-}
   getTrait :: Body val -> ServerHandler m (Linked ts Request) (Either Text val)
   getTrait (Body _) = arrM $ \request -> do
     chunks <- takeWhileM (/= mempty) $ repeat $ liftIO $ getRequestBodyChunk $ unlink request
@@ -28,7 +28,7 @@ instance (MonadIO m, FromByteString val) => Get (ServerHandler m) (Body val) Req
       Right t -> Right t
 
 instance (Monad m, ToByteString val) => Set (ServerHandler m) (Body val) Response where
-  {-# INLINEABLE setTrait #-}
+  {-# INLINE setTrait #-}
   setTrait ::
     Body val ->
     (Linked ts Response -> Response -> val -> Linked (Body val : ts) Response) ->
@@ -47,7 +47,7 @@ instance (Monad m, ToByteString val) => Set (ServerHandler m) (Body val) Respons
     returnA -< f linkedResponse response' val
 
 instance (MonadIO m, Aeson.FromJSON val) => Get (ServerHandler m) (JSONBody val) Request where
-  {-# INLINEABLE getTrait #-}
+  {-# INLINE getTrait #-}
   getTrait :: JSONBody val -> ServerHandler m (Linked ts Request) (Either Text val)
   getTrait (JSONBody _) = arrM $ \request -> do
     chunks <- takeWhileM (/= mempty) $ repeat $ liftIO $ getRequestBodyChunk $ unlink request
@@ -56,7 +56,7 @@ instance (MonadIO m, Aeson.FromJSON val) => Get (ServerHandler m) (JSONBody val)
       Right t -> Right t
 
 instance (Monad m, Aeson.ToJSON val) => Set (ServerHandler m) (JSONBody val) Response where
-  {-# INLINEABLE setTrait #-}
+  {-# INLINE setTrait #-}
   setTrait ::
     JSONBody val ->
     (Linked ts Response -> Response -> val -> Linked (JSONBody val : ts) Response) ->

--- a/webgear-server/src/WebGear/Server/Trait/Header.hs
+++ b/webgear-server/src/WebGear/Server/Trait/Header.hs
@@ -29,7 +29,7 @@ extractRequestHeader proxy = proc req -> do
   returnA -< parseHeader <$> requestHeader headerName (unlink req)
 
 instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler m) (Header Required Strict name val) Request where
-  {-# INLINEABLE getTrait #-}
+  {-# INLINE getTrait #-}
   getTrait ::
     Header Required Strict name val ->
     ServerHandler m (Linked ts Request) (Either (Either HeaderNotFound HeaderParseError) val)
@@ -41,7 +41,7 @@ instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler 
         Just (Right x) -> Right x
 
 instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler m) (Header Optional Strict name val) Request where
-  {-# INLINEABLE getTrait #-}
+  {-# INLINE getTrait #-}
   getTrait ::
     Header Optional Strict name val ->
     ServerHandler m (Linked ts Request) (Either HeaderParseError (Maybe val))
@@ -53,7 +53,7 @@ instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler 
         Just (Right x) -> Right $ Just x
 
 instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler m) (Header Required Lenient name val) Request where
-  {-# INLINEABLE getTrait #-}
+  {-# INLINE getTrait #-}
   getTrait ::
     Header Required Lenient name val ->
     ServerHandler m (Linked ts Request) (Either HeaderNotFound (Either Text val))
@@ -65,7 +65,7 @@ instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler 
         Just (Right x) -> Right $ Right x
 
 instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler m) (Header Optional Lenient name val) Request where
-  {-# INLINEABLE getTrait #-}
+  {-# INLINE getTrait #-}
   getTrait ::
     Header Optional Lenient name val ->
     ServerHandler m (Linked ts Request) (Either Void (Maybe (Either Text val)))
@@ -77,7 +77,7 @@ instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler 
         Just (Right x) -> Right $ Just $ Right x
 
 instance (Monad m, KnownSymbol name, ToByteString val) => Set (ServerHandler m) (Header Required Strict name val) Response where
-  {-# INLINEABLE setTrait #-}
+  {-# INLINE setTrait #-}
   setTrait ::
     Header Required Strict name val ->
     (Linked ts Response -> Response -> val -> Linked (Header Required Strict name val : ts) Response) ->
@@ -89,7 +89,7 @@ instance (Monad m, KnownSymbol name, ToByteString val) => Set (ServerHandler m) 
     returnA -< f l response' val
 
 instance (Monad m, KnownSymbol name, ToByteString val) => Set (ServerHandler m) (Header Optional Strict name val) Response where
-  {-# INLINEABLE setTrait #-}
+  {-# INLINE setTrait #-}
   setTrait ::
     Header Optional Strict name val ->
     (Linked ts Response -> Response -> Maybe val -> Linked (Header Optional Strict name val : ts) Response) ->

--- a/webgear-server/src/WebGear/Server/Trait/Method.hs
+++ b/webgear-server/src/WebGear/Server/Trait/Method.hs
@@ -11,7 +11,7 @@ import WebGear.Core.Trait.Method (Method (..), MethodMismatch (..))
 import WebGear.Server.Handler (ServerHandler)
 
 instance Monad m => Get (ServerHandler m) Method Request where
-  {-# INLINEABLE getTrait #-}
+  {-# INLINE getTrait #-}
   getTrait :: Method -> ServerHandler m (Linked ts Request) (Either MethodMismatch HTTP.StdMethod)
   getTrait (Method method) = proc request -> do
     let expectedMethod = HTTP.renderStdMethod method

--- a/webgear-server/src/WebGear/Server/Trait/Path.hs
+++ b/webgear-server/src/WebGear/Server/Trait/Path.hs
@@ -13,7 +13,7 @@ import WebGear.Core.Trait.Path (Path (..), PathEnd (..), PathVar (..), PathVarEr
 import WebGear.Server.Handler (ServerHandler (..))
 
 instance Monad m => Get (ServerHandler m) Path Request where
-  {-# INLINEABLE getTrait #-}
+  {-# INLINE getTrait #-}
   getTrait :: Path -> ServerHandler m (Linked ts Request) (Either () ())
   getTrait (Path p) = ServerHandler $ \(_, path@(RoutePath remaining)) -> do
     let expected = filter (/= "") $ Text.splitOn "/" p
@@ -22,7 +22,7 @@ instance Monad m => Get (ServerHandler m) Path Request where
       Nothing -> (Right (Left ()), path)
 
 instance (Monad m, FromHttpApiData val) => Get (ServerHandler m) (PathVar tag val) Request where
-  {-# INLINEABLE getTrait #-}
+  {-# INLINE getTrait #-}
   getTrait :: PathVar tag val -> ServerHandler m (Linked ts Request) (Either PathVarError val)
   getTrait PathVar = ServerHandler $ \(_, path@(RoutePath remaining)) -> do
     pure $ case remaining of
@@ -33,7 +33,7 @@ instance (Monad m, FromHttpApiData val) => Get (ServerHandler m) (PathVar tag va
           Right val -> (Right (Right val), RoutePath ps)
 
 instance Monad m => Get (ServerHandler m) PathEnd Request where
-  {-# INLINEABLE getTrait #-}
+  {-# INLINE getTrait #-}
   getTrait :: PathEnd -> ServerHandler m (Linked ts Request) (Either () ())
   getTrait PathEnd = ServerHandler f
     where

--- a/webgear-server/src/WebGear/Server/Trait/QueryParam.hs
+++ b/webgear-server/src/WebGear/Server/Trait/QueryParam.hs
@@ -32,7 +32,7 @@ extractQueryParam proxy = proc req -> do
   returnA -< parseQueryParam <$> (find ((== name) . fst) params >>= snd)
 
 instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler m) (QueryParam Required Strict name val) Request where
-  {-# INLINEABLE getTrait #-}
+  {-# INLINE getTrait #-}
   getTrait ::
     QueryParam Required Strict name val ->
     ServerHandler m (Linked ts Request) (Either (Either ParamNotFound ParamParseError) val)
@@ -44,7 +44,7 @@ instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler 
         Just (Right x) -> Right x
 
 instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler m) (QueryParam Optional Strict name val) Request where
-  {-# INLINEABLE getTrait #-}
+  {-# INLINE getTrait #-}
   getTrait ::
     QueryParam Optional Strict name val ->
     ServerHandler m (Linked ts Request) (Either ParamParseError (Maybe val))
@@ -56,7 +56,7 @@ instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler 
         Just (Right x) -> Right $ Just x
 
 instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler m) (QueryParam Required Lenient name val) Request where
-  {-# INLINEABLE getTrait #-}
+  {-# INLINE getTrait #-}
   getTrait ::
     QueryParam Required Lenient name val ->
     ServerHandler m (Linked ts Request) (Either ParamNotFound (Either Text val))
@@ -68,7 +68,7 @@ instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler 
         Just (Right x) -> Right $ Right x
 
 instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler m) (QueryParam Optional Lenient name val) Request where
-  {-# INLINEABLE getTrait #-}
+  {-# INLINE getTrait #-}
   getTrait ::
     QueryParam Optional Lenient name val ->
     ServerHandler m (Linked ts Request) (Either Void (Maybe (Either Text val)))

--- a/webgear-server/src/WebGear/Server/Trait/Status.hs
+++ b/webgear-server/src/WebGear/Server/Trait/Status.hs
@@ -11,7 +11,7 @@ import WebGear.Core.Trait.Status (Status (..))
 import WebGear.Server.Handler (ServerHandler)
 
 instance Monad m => Set (ServerHandler m) Status Response where
-  {-# INLINEABLE setTrait #-}
+  {-# INLINE setTrait #-}
   setTrait ::
     Status ->
     (Linked ts Response -> Response -> HTTP.Status -> Linked (Status : ts) Response) ->


### PR DESCRIPTION
WebGear has a performance degradation in GHC 9.2.x compared to previous GHC versions. It looks like servant and scotty get optimized better in 9.2.x compared to WebGear.

Adding INLINE pragmas brings benchmark numbers closer to servant and scotty.

Sample benchmark:

```
Run GHC_VERSION=$(echo 9.2.4 | tr -d .)
  GHC_VERSION=$(echo 9.2.4 | tr -d .)
  BENCHMARK=$(nix build --no-link --json .#webgear-benchmarks-ghc${GHC_VERSION} | jq -r .[].outputs.out)
  ${BENCHMARK}/bin/users +RTS -N -RTS
  shell: /usr/bin/bash -e {0}
benchmarking webgear/500
time                 10.57 ms   (10.53 ms .. 10.63 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 10.58 ms   (10.54 ms .. 10.64 ms)
std dev              112.5 μs   (78.97 μs .. 158.0 μs)

benchmarking webgear/1000
time                 21.17 ms   (21.07 ms .. 21.32 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 21.09 ms   (21.04 ms .. 21.19 ms)
std dev              165.3 μs   (68.31 μs .. 268.5 μs)

benchmarking webgear/5000
time                 105.9 ms   (105.2 ms .. 106.6 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 105.9 ms   (105.7 ms .. 106.3 ms)
std dev              423.9 μs   (253.2 μs .. 615.2 μs)

benchmarking servant/500
time                 8.338 ms   (8.329 ms .. 8.352 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 8.335 ms   (8.329 ms .. 8.344 ms)
std dev              22.53 μs   (15.68 μs .. 36.11 μs)

benchmarking servant/1000
time                 16.76 ms   (16.68 ms .. 16.83 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 16.75 ms   (16.71 ms .. 16.79 ms)
std dev              107.7 μs   (60.38 μs .. 156.1 μs)

benchmarking servant/5000
time                 83.39 ms   (83.09 ms .. 83.59 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 83.42 ms   (83.33 ms .. 83.55 ms)
std dev              177.9 μs   (133.6 μs .. 238.5 μs)

benchmarking scotty/500
time                 10.19 ms   (10.17 ms .. 10.21 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 10.18 ms   (10.17 ms .. 10.22 ms)
std dev              64.47 μs   (18.69 μs .. 128.4 μs)

benchmarking scotty/1000
time                 20.19 ms   (20.05 ms .. 20.27 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 20.31 ms   (20.24 ms .. 20.55 ms)
std dev              278.3 μs   (51.45 μs .. 537.0 μs)

benchmarking scotty/5000
time                 101.7 ms   (101.0 ms .. 102.9 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 101.6 ms   (101.3 ms .. 102.0 ms)
std dev              546.6 μs   (252.2 μs .. 817.6 μs)
```