### PR TITLE
Refactor APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Documentation is available at https://haskell-webgear.github.io
 Use Nix to start a reproducible development environment:
 
 ```shell
+nix develop
+```
+
+This starts a shell with the default GHC. You can also use a specific GHC version with:
+
+```shell
 nix develop .#webgear-dev-ghc<GHC-VERSION>
 ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -27,9 +27,13 @@
             name = "${name}-ghc${ghcVersion}";
             value = pkgs.haskell.packages."ghc${ghcVersion}".${name};
           }) pkgs.localHsPackages;
+
+        devShells = pkgs.lib.mapcat pkgs.mkDevShell pkgs.ghcVersions;
       in {
         packages = pkgs.lib.mapcat mkVersionedPackages pkgs.ghcVersions;
 
-        devShells = pkgs.lib.mapcat pkgs.mkDevShell pkgs.ghcVersions;
+        devShells = devShells // {
+          default = devShells."webgear-dev-ghc${pkgs.defaultGHCVersion}";
+        };
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -22,14 +22,14 @@
           overlays = [ self.overlays.default ];
         };
 
-        mkVersionedPackages = hsVersion:
+        mkVersionedPackages = ghcVersion:
           pkgs.lib.attrsets.mapAttrs' (name: _: {
-            name = "${name}-${hsVersion}";
-            value = pkgs.haskell.packages.${hsVersion}.${name};
+            name = "${name}-ghc${ghcVersion}";
+            value = pkgs.haskell.packages."ghc${ghcVersion}".${name};
           }) pkgs.localHsPackages;
       in {
-        packages = pkgs.lib.mapcat mkVersionedPackages pkgs.hsVersions;
+        packages = pkgs.lib.mapcat mkVersionedPackages pkgs.ghcVersions;
 
-        devShells = pkgs.lib.mapcat pkgs.mkDevShell pkgs.hsVersions;
+        devShells = pkgs.lib.mapcat pkgs.mkDevShell pkgs.ghcVersions;
       });
 }

--- a/nix/overlays/haskell.nix
+++ b/nix/overlays/haskell.nix
@@ -80,7 +80,7 @@ let
         };
     in { ${shell.name} = shell; };
 in {
-  inherit ghcVersions;
+  inherit ghcVersions defaultGHCVersion;
 
   lib = prev.lib // {
     inherit mapcat;

--- a/webgear-benchmarks/src/users/Scotty.hs
+++ b/webgear-benchmarks/src/users/Scotty.hs
@@ -1,4 +1,4 @@
-module Scotty where
+module Scotty (application) where
 
 import Network.HTTP.Types (noContent204, notFound404)
 import Network.Wai

--- a/webgear-benchmarks/src/users/Servant.hs
+++ b/webgear-benchmarks/src/users/Servant.hs
@@ -1,4 +1,4 @@
-module Servant where
+module Servant (application) where
 
 import Control.Monad.Except (ExceptT, MonadError, mapExceptT, throwError)
 import Control.Monad.IO.Class (MonadIO)

--- a/webgear-benchmarks/src/users/WebGear.hs
+++ b/webgear-benchmarks/src/users/WebGear.hs
@@ -48,7 +48,7 @@ getUser = findUser >>> respond
     respond :: h (Maybe User) Response
     respond = proc maybeUser -> case maybeUser of
       Nothing -> unwitnessA <<< notFound404 -< ()
-      Just u -> unwitnessA <<< respondJsonA HTTP.ok200 -< u
+      Just u -> respondJsonA HTTP.ok200 -< u
 
 putUser ::
   forall h req.
@@ -62,7 +62,7 @@ putUser = jsonRequestBody @User badPayload $ doUpdate >>> respond
   where
     badPayload :: h (Request `With` req, Text) Response
     badPayload = proc _ ->
-      unwitnessA <<< respondA HTTP.badRequest400 "text/plain" -< "Invalid body payload" :: Text
+      respondA HTTP.badRequest400 "text/plain" -< "Invalid body payload" :: Text
 
     doUpdate :: (HaveTraits [UserIdPathVar, JSONBody User] ts) => h (Request `With` ts) User
     doUpdate = arrM $ \request -> do
@@ -75,7 +75,7 @@ putUser = jsonRequestBody @User badPayload $ doUpdate >>> respond
 
     respond :: h User Response
     respond = proc user ->
-      unwitnessA <<< respondJsonA HTTP.ok200 -< user
+      respondJsonA HTTP.ok200 -< user
 
 deleteUser ::
   forall h req.

--- a/webgear-benchmarks/src/users/WebGear.hs
+++ b/webgear-benchmarks/src/users/WebGear.hs
@@ -17,30 +17,31 @@ type AppM = ReaderT UserStore IO
 type UserIdPathVar = PathVar "userId" Int
 
 allRoutes ::
-  StdHandler
-    h
-    AppM
-    [UserIdPathVar, JSONBody User]
-    [Body Text, RequiredHeader "Content-Type" Text, JSONBody User] =>
-  h (Linked '[] Request) Response
+  ( StdHandler
+      h
+      AppM
+      [UserIdPathVar, JSONBody User]
+      [Body Text, RequiredHeader "Content-Type" Text, JSONBody User]
+  ) =>
+  h (Request `With` '[]) Response
 allRoutes =
   -- TH version: [route| /v1/users/userId:Int |]
-  path "/v1/users" $
-    pathVar @"userId" @Int $
-      pathEnd $
-        method GET getUser
-          <+> method PUT putUser
-          <+> method DELETE deleteUser
+  path "/v1/users"
+    $ pathVar @"userId" @Int
+    $ pathEnd
+    $ method GET getUser
+    <+> method PUT putUser
+    <+> method DELETE deleteUser
 
 getUser ::
   forall h req.
   ( HasTrait UserIdPathVar req
   , StdHandler h AppM '[] [RequiredHeader "Content-Type" Text, JSONBody User]
   ) =>
-  h (Linked req Request) Response
+  h (Request `With` req) Response
 getUser = findUser >>> respond
   where
-    findUser :: h (Linked req Request) (Maybe User)
+    findUser :: h (Request `With` req) (Maybe User)
     findUser = arrM $ \request -> do
       let uid = pick @UserIdPathVar $ from request
       store <- ask
@@ -48,8 +49,8 @@ getUser = findUser >>> respond
 
     respond :: h (Maybe User) Response
     respond = proc maybeUser -> case maybeUser of
-      Nothing -> unlinkA <<< notFound404 -< ()
-      Just u -> unlinkA <<< respondJsonA HTTP.ok200 -< u
+      Nothing -> unwitnessA <<< notFound404 -< ()
+      Just u -> unwitnessA <<< respondJsonA HTTP.ok200 -< u
 
 putUser ::
   forall h req.
@@ -60,14 +61,14 @@ putUser ::
       '[JSONBody User]
       [RequiredHeader "Content-Type" Text, JSONBody User, Body Text]
   ) =>
-  h (Linked req Request) Response
+  h (Request `With` req) Response
 putUser = jsonRequestBody @User badPayload $ doUpdate >>> respond
   where
-    badPayload :: h (Linked req Request, Text) Response
+    badPayload :: h (Request `With` req, Text) Response
     badPayload = proc _ ->
-      unlinkA <<< respondA HTTP.badRequest400 "text/plain" -< "Invalid body payload" :: Text
+      unwitnessA <<< respondA HTTP.badRequest400 "text/plain" -< "Invalid body payload" :: Text
 
-    doUpdate :: HaveTraits [UserIdPathVar, JSONBody User] ts => h (Linked ts Request) User
+    doUpdate :: (HaveTraits [UserIdPathVar, JSONBody User] ts) => h (Request `With` ts) User
     doUpdate = arrM $ \request -> do
       let uid = pick @UserIdPathVar $ from request
           user = pick @(JSONBody User) $ from request
@@ -78,15 +79,15 @@ putUser = jsonRequestBody @User badPayload $ doUpdate >>> respond
 
     respond :: h User Response
     respond = proc user ->
-      unlinkA <<< respondJsonA HTTP.ok200 -< user
+      unwitnessA <<< respondJsonA HTTP.ok200 -< user
 
 deleteUser ::
   forall h req.
   (HasTrait UserIdPathVar req, StdHandler h AppM '[] '[]) =>
-  h (Linked req Request) Response
+  h (Request `With` req) Response
 deleteUser = doDelete >>> respond
   where
-    doDelete :: h (Linked req Request) Bool
+    doDelete :: h (Request `With` req) Bool
     doDelete = arrM $ \request -> do
       let uid = pick @UserIdPathVar $ from request
       store <- ask
@@ -95,8 +96,8 @@ deleteUser = doDelete >>> respond
     respond :: h Bool Response
     respond = proc removed ->
       if removed
-        then unlinkA <<< noContent204 -< ()
-        else unlinkA <<< notFound404 -< ()
+        then unwitnessA <<< noContent204 -< ()
+        else unwitnessA <<< notFound404 -< ()
 
 --------------------------------------------------------------------------------
 

--- a/webgear-benchmarks/src/users/WebGear.hs
+++ b/webgear-benchmarks/src/users/WebGear.hs
@@ -19,7 +19,7 @@ type UserIdPathVar = PathVar "userId" Int
 allRoutes ::
   ( StdHandler h AppM
   , Gets h [UserIdPathVar, JSONBody User] Request
-  , Sets h [RequiredHeader "Content-Type" Text, JSONBody User, Body Text] Response
+  , Sets h [RequiredResponseHeader "Content-Type" Text, JSONBody User, Body Text] Response
   ) =>
   h (Request `With` '[]) Response
 allRoutes =
@@ -34,7 +34,7 @@ getUser ::
   forall h req.
   ( HasTrait UserIdPathVar req
   , StdHandler h AppM
-  , Sets h [RequiredHeader "Content-Type" Text, JSONBody User] Response
+  , Sets h [RequiredResponseHeader "Content-Type" Text, JSONBody User] Response
   ) =>
   h (Request `With` req) Response
 getUser = findUser >>> respond
@@ -55,7 +55,7 @@ putUser ::
   ( HasTrait UserIdPathVar req
   , StdHandler h AppM
   , Get h (JSONBody User) Request
-  , Sets h [RequiredHeader "Content-Type" Text, JSONBody User, Body Text] Response
+  , Sets h [RequiredResponseHeader "Content-Type" Text, JSONBody User, Body Text] Response
   ) =>
   h (Request `With` req) Response
 putUser = jsonRequestBody @User badPayload $ doUpdate >>> respond

--- a/webgear-benchmarks/webgear-benchmarks.cabal
+++ b/webgear-benchmarks/webgear-benchmarks.cabal
@@ -35,6 +35,7 @@ executable users
                     , wai ==3.2.3
                     , webgear-server ==1.1.0
   default-extensions: Arrows
+                      ConstraintKinds
                       DataKinds
                       DeriveAnyClass
                       DeriveGeneric

--- a/webgear-core/src/WebGear/Core/Handler/Static.hs
+++ b/webgear-core/src/WebGear/Core/Handler/Static.hs
@@ -18,7 +18,7 @@ import WebGear.Core.Request (Request (..))
 import WebGear.Core.Response (Response)
 import WebGear.Core.Trait (Sets, With)
 import WebGear.Core.Trait.Body (Body, setBodyWithoutContentType)
-import WebGear.Core.Trait.Header (RequiredHeader, setHeader)
+import WebGear.Core.Trait.Header (RequiredResponseHeader, setHeader)
 import WebGear.Core.Trait.Status (Status, notFound404, ok200)
 import Prelude hiding (readFile)
 
@@ -26,7 +26,7 @@ import Prelude hiding (readFile)
 serveDir ::
   ( MonadIO m
   , Handler h m
-  , Sets h [Status, RequiredHeader "Content-Type" Mime.MimeType, Body LBS.ByteString] Response
+  , Sets h [Status, RequiredResponseHeader "Content-Type" Mime.MimeType, Body LBS.ByteString] Response
   ) =>
   -- | The directory to serve
   FilePath ->
@@ -47,7 +47,7 @@ serveDir root index = proc _request -> consumeRoute go -< ()
 serveFile ::
   ( MonadIO m
   , Handler h m
-  , Sets h [Status, RequiredHeader "Content-Type" Mime.MimeType, Body LBS.ByteString] Response
+  , Sets h [Status, RequiredResponseHeader "Content-Type" Mime.MimeType, Body LBS.ByteString] Response
   ) =>
   h FilePath Response
 serveFile = proc file -> do

--- a/webgear-core/src/WebGear/Core/Request.hs
+++ b/webgear-core/src/WebGear/Core/Request.hs
@@ -25,8 +25,8 @@ import qualified Network.Wai as Wai
 
 -- | A request processed by a handler
 newtype Request = Request
-  { -- | underlying WAI request
-    waiRequest :: Wai.Request
+  { toWaiRequest :: Wai.Request
+  -- ^ underlying WAI request
   }
 
 -- | Get the value of a request header
@@ -35,36 +35,36 @@ requestHeader h r = snd <$> find ((== h) . fst) (requestHeaders r)
 
 -- | See 'Wai.getRequestBodyChunk'
 getRequestBodyChunk :: Request -> IO ByteString
-getRequestBodyChunk = Wai.getRequestBodyChunk . waiRequest
+getRequestBodyChunk = Wai.getRequestBodyChunk . toWaiRequest
 
 -- | See 'Wai.httpVersion'
 httpVersion :: Request -> HTTP.HttpVersion
-httpVersion = Wai.httpVersion . waiRequest
+httpVersion = Wai.httpVersion . toWaiRequest
 
 -- | See 'Wai.isSecure'
 isSecure :: Request -> Bool
-isSecure = Wai.isSecure . waiRequest
+isSecure = Wai.isSecure . toWaiRequest
 
 -- | See 'Wai.pathInfo'
 pathInfo :: Request -> [Text]
-pathInfo = Wai.pathInfo . waiRequest
+pathInfo = Wai.pathInfo . toWaiRequest
 
 -- | See 'Wai.queryString'
 queryString :: Request -> HTTP.Query
-queryString = Wai.queryString . waiRequest
+queryString = Wai.queryString . toWaiRequest
 
 -- | See 'Wai.remoteHost'
 remoteHost :: Request -> SockAddr
-remoteHost = Wai.remoteHost . waiRequest
+remoteHost = Wai.remoteHost . toWaiRequest
 
 -- | See 'Wai.requestBodyLength'
 requestBodyLength :: Request -> Wai.RequestBodyLength
-requestBodyLength = Wai.requestBodyLength . waiRequest
+requestBodyLength = Wai.requestBodyLength . toWaiRequest
 
 -- | See 'Wai.requestHeaders'
 requestHeaders :: Request -> HTTP.RequestHeaders
-requestHeaders = Wai.requestHeaders . waiRequest
+requestHeaders = Wai.requestHeaders . toWaiRequest
 
 -- | See 'Wai.requestMethod'
 requestMethod :: Request -> HTTP.Method
-requestMethod = Wai.requestMethod . waiRequest
+requestMethod = Wai.requestMethod . toWaiRequest

--- a/webgear-core/src/WebGear/Core/Trait.hs
+++ b/webgear-core/src/WebGear/Core/Trait.hs
@@ -3,15 +3,45 @@
 {- | Traits are optional attributes associated with a value. For
  example, a list containing totally ordered values might have a
  @Maximum@ trait where the associated attribute is the maximum
- value. This trait exists only if the list is non-empty. The `Trait`
+ value. This trait exists only if the list is non-empty. The 'Trait'
  typeclass provides an interface to extract such trait attributes.
 
- Traits help to link attributes with values in a type-safe manner.
+ Traits help to associate attributes with values in a type-safe
+ manner.
 
  Traits are somewhat similar to [refinement
  types](https://hackage.haskell.org/package/refined), but allow
- arbitrary attributes to be associated with a value instead of only
- a predicate.
+ arbitrary attributes to be associated with a value instead of only a
+ predicate.
+
+ A value @a@ associated with traits @ts@ is referred to as a witnessed
+ value, represented by the type @a \`'With'\` ts@ where @ts@ is a
+ type-level list. You can extract a trait attribute from a witnessed
+ value with:
+
+ @
+ `pick` \@t (`from` witnessedValue)
+ @
+
+ The above expression will result in a compile-time error if @t@ is
+ not present in the type-level list of the witnessed value's type.
+
+ You can create a witnessed value in a number of ways:
+
+ First, you can use 'wzero' to lift a regular value to a witnessed
+ value with no associated traits.
+
+ Second, you can use 'probe' to search for the presence of a trait and
+ add it to the witnessed value; this will adjust the type-level list
+ accordingly. This is used in cases where the regular value already
+ contains the trait attribute which can be extracted using the 'Get'
+ typeclass.
+
+ Third, you can use 'plant' to add a trait attribute to a witnessed
+ value, thereby extending its type-level list with one more
+ trait. This is used in cases where you want to modify the witnessed
+ value. This operation requires an implementation of the 'Set'
+ typeclass.
 -}
 module WebGear.Core.Trait (
   -- * Core Types
@@ -19,18 +49,18 @@ module WebGear.Core.Trait (
   TraitAbsence (..),
   Get (..),
   Gets,
-  Linked,
   Set (..),
   Sets,
+  With,
 
-  -- * Linking values with attributes
-  linkzero,
-  linkminus,
-  unlink,
+  -- * Associating values with attributes
+  wzero,
+  wminus,
+  unwitness,
   probe,
   plant,
 
-  -- * Retrive trait attributes from linked values
+  -- * Retrieve trait attributes from witnessed values
   HasTrait (..),
   HaveTraits,
   pick,
@@ -49,33 +79,34 @@ class Trait (t :: Type) a where
   type Attribute t a :: Type
 
 -- | A trait @t@ that can be retrieved from @a@ but could be absent.
-class Trait t a => TraitAbsence t a where
+class (Trait t a) => TraitAbsence t a where
   -- | Type that indicates that the trait does not exist for a
   -- value. This could be an error message, exception etc.
   type Absence t a :: Type
 
 -- | Extract trait attributes from a value.
 class (Arrow h, TraitAbsence t a) => Get h t a where
-  -- | Attempt to deduce the trait attribute from the value @a@.
+  -- | Attempt to witness the trait attribute from the value @a@.
   getTrait ::
-    -- | The trait to extract
+    -- | The trait to witness
     t ->
-    -- | Arrow that extracts the trait and can possibly fail
-    h (Linked ts a) (Either (Absence t a) (Attribute t a))
+    -- | Arrow that attemtps to witness the trait and can possibly
+    -- fail
+    h (a `With` ts) (Either (Absence t a) (Attribute t a))
 
--- | Set a trait attribute on a value
+-- | Associate a trait attribute on a value
 class (Arrow h, Trait t a) => Set h (t :: Type) a where
-  -- | Set a trait attribute @t@ on the value @a@.
+  -- | Set a trait attribute @t@ on the value @a \`With\` ts@.
   setTrait ::
     -- | The trait to set
     t ->
-    -- | A function to generate a linked value. This function must be
-    -- called by the `setTrait` implementation to generate a linked
+    -- | A function to generate a witnessed value. This function must
+    -- be called by the `setTrait` implementation to generate a
+    -- witnessed value.
+    (a `With` ts -> a -> Attribute t a -> a `With` (t : ts)) ->
+    -- | An arrow that attaches a new trait attribute to a witnessed
     -- value.
-    (Linked ts a -> a -> Attribute t a -> Linked (t : ts) a) ->
-    -- | An arrow that attches a new trait attribute to a value linked
-    -- with other traits
-    h (Linked ts a, Attribute t a) (Linked (t : ts) a)
+    h (a `With` ts, Attribute t a) (a `With` (t : ts))
 
 {- | @Gets h ts a@ is equivalent to @(Get h t1 a, Get h t2 a, ..., Get
  h tn a)@ where @ts = [t1, t2, ..., tn]@.
@@ -91,90 +122,119 @@ type family Sets h ts a :: Constraint where
   Sets h '[] a = ()
   Sets h (t : ts) a = (Set h t a, Sets h ts a)
 
--- | A value linked with a type-level list of traits.
-data Linked (ts :: [Type]) a = Linked
-  { linkAttribute :: !(LinkedAttributes ts a)
-  , unlink :: !a
-  -- ^ Retrive the value from a linked value
+{- | A value associated with a list of traits, referred to as a
+witnessed value. Typically, this is used as an infix type constructor:
+
+@
+a \`With\` ts
+@
+
+where @a@ is a value and @ts@ is a list of traits associated with
+that value.
+
+If @t@ is a type present in the list of types @ts@, it is possible to
+extract its attribute from a witnessed value:
+
+@
+let witnessedValue :: a \`With\` ts
+    witnessedValue = ...
+
+let attr :: `Attribute` t a
+    attr = `pick` \@t (`from` witnessedValue)
+@
+-}
+data With a (ts :: [Type]) = With
+  { attribute :: !(WitnessedAttribute ts a)
+  , unwitness :: !a
+  -- ^ Retrieve the value
   }
 
-type family LinkedAttributes (ts :: [Type]) (a :: Type) where
-  LinkedAttributes '[] a = ()
-  LinkedAttributes (t : ts) a = (Attribute t a, LinkedAttributes ts a)
+type family WitnessedAttribute (ts :: [Type]) (a :: Type) where
+  WitnessedAttribute '[] a = ()
+  WitnessedAttribute (t : ts) a = (Attribute t a, WitnessedAttribute ts a)
 
--- | Wrap a value with an empty list of traits.
-linkzero :: a -> Linked '[] a
-linkzero = Linked ()
-{-# INLINE linkzero #-}
+-- | Lift a value to a witnessed value having no associated traits.
+wzero :: a -> a `With` '[]
+wzero = With ()
+{-# INLINE wzero #-}
 
 -- | Forget the head trait
-linkminus :: Linked (t : ts) a -> Linked ts a
-linkminus (Linked (_, rv) a) = Linked rv a
-{-# INLINE linkminus #-}
+wminus :: a `With` (t : ts) -> a `With` ts
+wminus (With (_, rv) a) = With rv a
+{-# INLINE wminus #-}
 
-{- | Attempt to link an additional trait with an already linked
- value. This can fail indicating an 'Absence' of the trait.
+{- | Attempt to witness an additional trait with a witnessed value. This
+ can fail indicating an 'Absence' of the trait.
 -}
 probe ::
   forall t ts h a.
-  Get h t a =>
+  (Get h t a) =>
   t ->
-  h (Linked ts a) (Either (Absence t a) (Linked (t : ts) a))
+  h (a `With` ts) (Either (Absence t a) (a `With` (t : ts)))
 probe t = proc l -> do
   res <- getTrait t -< l
-  arr link -< (l, res)
+  arr add -< (l, res)
   where
-    link :: (Linked ts a, Either e (Attribute t a)) -> Either e (Linked (t : ts) a)
-    link (_, Left e) = Left e
-    link (Linked{..}, Right attr) = Right $ Linked{linkAttribute = (attr, linkAttribute), ..}
+    add :: (a `With` ts, Either e (Attribute t a)) -> Either e (a `With` (t : ts))
+    add (_, Left e) = Left e
+    add (With{..}, Right attr) = Right $ With{attribute = (attr, attribute), ..}
 {-# INLINE probe #-}
 
-{- | Set a trait attribute on linked value to produce another linked
- value
+{- | Set a trait attribute on witnessed value to produce another
+   witnessed value with the additional trait attached to it.
 -}
-plant :: forall t ts h a. Set h t a => t -> h (Linked ts a, Attribute t a) (Linked (t : ts) a)
+plant ::
+  forall t ts h a.
+  (Set h t a) =>
+  t ->
+  h (a `With` ts, Attribute t a) (a `With` (t : ts))
 plant t = proc (l, attr) -> do
-  setTrait t link -< (l, attr)
+  setTrait t add -< (l, attr)
   where
-    link :: Linked ts a -> a -> Attribute t a -> Linked (t : ts) a
-    link Linked{..} a' attr = Linked{linkAttribute = (attr, linkAttribute), unlink = a'}
+    add :: a `With` ts -> a -> Attribute t a -> a `With` (t : ts)
+    add With{..} a' attr = With{attribute = (attr, attribute), unwitness = a'}
 {-# INLINE plant #-}
 
 {- | Constraint that proves that the trait @t@ is present in the list
  of traits @ts@.
 -}
 class HasTrait t ts where
-  -- | Get the attribute associated with @t@ from a linked value. See also: 'pick'.
-  from :: Linked ts a -> Tagged t (Attribute t a)
+  -- | Get the attribute associated with @t@ from a witnessed
+  -- value. See also: 'pick'.
+  from :: a `With` ts -> Tagged t (Attribute t a)
 
 instance HasTrait t (t : ts) where
-  from :: Linked (t : ts) a -> Tagged t (Attribute t a)
-  from (Linked (lv, _) _) = Tagged lv
+  from :: a `With` (t : ts) -> Tagged t (Attribute t a)
+  from (With (lv, _) _) = Tagged lv
   {-# INLINE from #-}
 
-instance {-# OVERLAPPABLE #-} HasTrait t ts => HasTrait t (t' : ts) where
-  from :: Linked (t' : ts) a -> Tagged t (Attribute t a)
-  from l = from $ linkminus l
+instance {-# OVERLAPPABLE #-} (HasTrait t ts) => HasTrait t (t' : ts) where
+  from :: a `With` (t' : ts) -> Tagged t (Attribute t a)
+  from l = from $ wminus l
   {-# INLINE from #-}
 
 {- | Retrieve a trait.
 
- @pick@ is used along with `from` to retrieve an attribute from a
- linked value:
+ @pick@ is used along with 'from' to retrieve an attribute from a
+ witnessed value:
 
- > pick @t $ from val
+ @
+ pick @t (`from` val)
+ @
 -}
 pick :: Tagged t a -> a
 pick = untag
 {-# INLINE pick #-}
 
 -- For better type errors
-instance TypeError (MissingTrait t) => HasTrait t '[] where
+instance (TypeError (MissingTrait t)) => HasTrait t '[] where
   from = undefined
 
 -- | Type error for nicer UX of missing traits
 type MissingTrait t =
-  Text "The request doesn't have the trait ‘" :<>: ShowType t :<>: Text "’."
+  Text "The value doesn't have the trait ‘"
+    :<>: ShowType t
+    :<>: Text "’."
     :$$: Text ""
     :$$: Text "Did you use a wrong trait type?"
     :$$: Text "For e.g., ‘QueryParam \"foo\" Int’ instead of ‘QueryParam \"foo\" String’?"

--- a/webgear-core/src/WebGear/Core/Trait/Auth/Basic.hs
+++ b/webgear-core/src/WebGear/Core/Trait/Auth/Basic.hs
@@ -32,7 +32,7 @@
  authConfig :: 'BasicAuth' IO () 'Credentials'
  authConfig = 'BasicAuth'' { toBasicAttribute = pure . Right }
 
- type ErrorTraits = [Status, RequiredHeader \"Content-Type\" Text, RequiredHeader \"WWW-Authenticate\" Text, Body Text]
+ type ErrorTraits = [Status, RequiredRequestHeader \"Content-Type\" Text, RequiredRequestHeader \"WWW-Authenticate\" Text, Body Text]
 
  errorHandler :: ('Handler' h IO, Sets h ErrorTraits Response)
               => h (Request \`With\` req, 'BasicAuthError' e) Response

--- a/webgear-core/src/WebGear/Core/Trait/Auth/Common.hs
+++ b/webgear-core/src/WebGear/Core/Trait/Auth/Common.hs
@@ -27,12 +27,12 @@ import WebGear.Core.Request (Request)
 import WebGear.Core.Response (Response)
 import WebGear.Core.Trait (Get (..), Sets, With)
 import WebGear.Core.Trait.Body (Body, respondA)
-import WebGear.Core.Trait.Header (Header (..), RequiredHeader, setHeader)
+import WebGear.Core.Trait.Header (RequestHeader (..), RequiredResponseHeader, setHeader)
 import WebGear.Core.Trait.Status (Status)
 import Prelude hiding (break, drop)
 
 -- | Trait for \"Authorization\" header
-type AuthorizationHeader scheme = Header Optional Lenient "Authorization" (AuthToken scheme)
+type AuthorizationHeader scheme = RequestHeader Optional Lenient "Authorization" (AuthToken scheme)
 
 {- | Extract the \"Authorization\" header from a request by specifying
    an authentication scheme.
@@ -44,7 +44,7 @@ getAuthorizationHeaderTrait ::
   (Get h (AuthorizationHeader scheme) Request) =>
   h (Request `With` req) (Maybe (Either Text (AuthToken scheme)))
 getAuthorizationHeaderTrait = proc request -> do
-  result <- getTrait (Header :: Header Optional Lenient "Authorization" (AuthToken scheme)) -< request
+  result <- getTrait (RequestHeader :: RequestHeader Optional Lenient "Authorization" (AuthToken scheme)) -< request
   returnA -< either absurd id result
 {-# INLINE getAuthorizationHeaderTrait #-}
 
@@ -83,8 +83,8 @@ respondUnauthorized ::
   , Sets
       h
       [ Status
-      , RequiredHeader "Content-Type" Text
-      , RequiredHeader "WWW-Authenticate" Text
+      , RequiredResponseHeader "Content-Type" Text
+      , RequiredResponseHeader "WWW-Authenticate" Text
       , Body Text
       ]
       Response

--- a/webgear-core/src/WebGear/Core/Trait/Auth/JWT.hs
+++ b/webgear-core/src/WebGear/Core/Trait/Auth/JWT.hs
@@ -36,7 +36,7 @@
    , toJWTAttribute = pure . Right
    }
 
- type ErrorTraits = [Status, RequiredHeader \"Content-Type\" Text, RequiredHeader \"WWW-Authenticate\" Text, Body Text]
+ type ErrorTraits = [Status, RequiredRequestHeader \"Content-Type\" Text, RequiredRequestHeader \"WWW-Authenticate\" Text, Body Text]
 
  errorHandler :: ('Handler' h IO, Sets h ErrorTraits Response)
               => h (Request \`With\` req, 'JWTAuthError' e) Response

--- a/webgear-core/src/WebGear/Core/Trait/Body.hs
+++ b/webgear-core/src/WebGear/Core/Trait/Body.hs
@@ -55,7 +55,7 @@ import WebGear.Core.Handler (Middleware)
 import WebGear.Core.Request (Request)
 import WebGear.Core.Response (Response)
 import WebGear.Core.Trait (Get, Set, Sets, Trait (..), TraitAbsence (..), With, plant, probe)
-import WebGear.Core.Trait.Header (Header (..), RequiredHeader)
+import WebGear.Core.Trait.Header (RequiredResponseHeader, ResponseHeader (..))
 import WebGear.Core.Trait.Status (Status, mkResponse)
 
 -- | Request or response body with a type @t@.
@@ -147,14 +147,14 @@ jsonRequestBody = jsonRequestBody' (Just "application/json")
 -}
 setBody ::
   forall body h res.
-  (Sets h [Body body, RequiredHeader "Content-Type" Text] Response) =>
+  (Sets h [Body body, RequiredResponseHeader "Content-Type" Text] Response) =>
   -- | The media type of the response body
   HTTP.MediaType ->
-  h (Response `With` res, body) (Response `With` (RequiredHeader "Content-Type" Text : Body body : res))
+  h (Response `With` res, body) (Response `With` (RequiredResponseHeader "Content-Type" Text : Body body : res))
 setBody mediaType = proc (response, body) -> do
   response' <- plant (Body (Just mediaType)) -< (response, body)
   let mt = decodeUtf8 $ HTTP.renderHeader mediaType
-  plant Header -< (response', mt)
+  plant ResponseHeader -< (response', mt)
 {-# INLINE setBody #-}
 
 -- | Set the response body without specifying any media type.
@@ -171,8 +171,8 @@ setBodyWithoutContentType = plant (Body Nothing)
 -}
 setJSONBody ::
   forall body h res.
-  (Sets h [JSONBody body, RequiredHeader "Content-Type" Text] Response) =>
-  h (Response `With` res, body) (Response `With` (RequiredHeader "Content-Type" Text : JSONBody body : res))
+  (Sets h [JSONBody body, RequiredResponseHeader "Content-Type" Text] Response) =>
+  h (Response `With` res, body) (Response `With` (RequiredResponseHeader "Content-Type" Text : JSONBody body : res))
 setJSONBody = setJSONBodyWithContentType "application/json"
 {-# INLINE setJSONBody #-}
 
@@ -182,14 +182,14 @@ setJSONBody = setJSONBodyWithContentType "application/json"
 -}
 setJSONBodyWithContentType ::
   forall body h res.
-  (Sets h [JSONBody body, RequiredHeader "Content-Type" Text] Response) =>
+  (Sets h [JSONBody body, RequiredResponseHeader "Content-Type" Text] Response) =>
   -- | The media type of the response body
   HTTP.MediaType ->
-  h (Response `With` res, body) (Response `With` (RequiredHeader "Content-Type" Text : JSONBody body : res))
+  h (Response `With` res, body) (Response `With` (RequiredResponseHeader "Content-Type" Text : JSONBody body : res))
 setJSONBodyWithContentType mediaType = proc (response, body) -> do
   response' <- plant (JSONBody (Just mediaType)) -< (response, body)
   let mt = decodeUtf8 $ HTTP.renderHeader mediaType
-  plant Header -< (response', mt)
+  plant ResponseHeader -< (response', mt)
 {-# INLINE setJSONBodyWithContentType #-}
 
 {- | Set the response body to a JSON value without specifying any
@@ -209,12 +209,12 @@ setJSONBodyWithoutContentType = plant (JSONBody Nothing)
 -}
 respondA ::
   forall body h.
-  (Sets h [Status, Body body, RequiredHeader "Content-Type" Text] Response) =>
+  (Sets h [Status, Body body, RequiredResponseHeader "Content-Type" Text] Response) =>
   -- | Response status
   HTTP.Status ->
   -- | Media type of the response body
   HTTP.MediaType ->
-  h body (Response `With` [RequiredHeader "Content-Type" Text, Body body, Status])
+  h body (Response `With` [RequiredResponseHeader "Content-Type" Text, Body body, Status])
 respondA status mediaType = proc body -> do
   response <- mkResponse status -< ()
   setBody mediaType -< (response, body)
@@ -227,10 +227,10 @@ respondA status mediaType = proc body -> do
 -}
 respondJsonA ::
   forall body h.
-  (Sets h [Status, JSONBody body, RequiredHeader "Content-Type" Text] Response) =>
+  (Sets h [Status, JSONBody body, RequiredResponseHeader "Content-Type" Text] Response) =>
   -- | Response status
   HTTP.Status ->
-  h body (Response `With` [RequiredHeader "Content-Type" Text, JSONBody body, Status])
+  h body (Response `With` [RequiredResponseHeader "Content-Type" Text, JSONBody body, Status])
 respondJsonA status = respondJsonWithContentTypeA status "application/json"
 {-# INLINE respondJsonA #-}
 
@@ -242,12 +242,12 @@ respondJsonA status = respondJsonWithContentTypeA status "application/json"
 -}
 respondJsonWithContentTypeA ::
   forall body h.
-  (Sets h [Status, JSONBody body, RequiredHeader "Content-Type" Text] Response) =>
+  (Sets h [Status, JSONBody body, RequiredResponseHeader "Content-Type" Text] Response) =>
   -- | Response status
   HTTP.Status ->
   -- | Media type of the response body
   HTTP.MediaType ->
-  h body (Response `With` [RequiredHeader "Content-Type" Text, JSONBody body, Status])
+  h body (Response `With` [RequiredResponseHeader "Content-Type" Text, JSONBody body, Status])
 respondJsonWithContentTypeA status mediaType = proc body -> do
   response <- mkResponse status -< ()
   setJSONBodyWithContentType mediaType -< (response, body)

--- a/webgear-core/src/WebGear/Core/Trait/Header.hs
+++ b/webgear-core/src/WebGear/Core/Trait/Header.hs
@@ -27,11 +27,14 @@
 -}
 module WebGear.Core.Trait.Header (
   -- * Traits
-  Header (..),
+  RequestHeader (..),
   HeaderNotFound (..),
   HeaderParseError (..),
-  RequiredHeader,
-  OptionalHeader,
+  RequiredRequestHeader,
+  OptionalRequestHeader,
+  ResponseHeader (..),
+  RequiredResponseHeader,
+  OptionalResponseHeader,
 
   -- * Middlewares
   header,
@@ -74,46 +77,46 @@ newtype HeaderParseError = HeaderParseError Text
  how missing headers and parsing errors are handled. The header name
  is compared case-insensitively.
 -}
-data Header (e :: Existence) (p :: ParseStyle) (name :: Symbol) (val :: Type) = Header
+data RequestHeader (e :: Existence) (p :: ParseStyle) (name :: Symbol) (val :: Type) = RequestHeader
 
--- | A `Header` that is required and parsed strictly
-type RequiredHeader = Header Required Strict
+-- | A `Header` that is required in the request and parsed strictly
+type RequiredRequestHeader = RequestHeader Required Strict
 
--- | A `Header` that is optional and parsed strictly
-type OptionalHeader = Header Optional Strict
+-- | A `Header` that is optional in the request and parsed strictly
+type OptionalRequestHeader = RequestHeader Optional Strict
 
-instance Trait (Header Required Strict name val) Request where
-  type Attribute (Header Required Strict name val) Request = val
+instance Trait (RequestHeader Required Strict name val) Request where
+  type Attribute (RequestHeader Required Strict name val) Request = val
 
-instance TraitAbsence (Header Required Strict name val) Request where
-  type Absence (Header Required Strict name val) Request = Either HeaderNotFound HeaderParseError
+instance TraitAbsence (RequestHeader Required Strict name val) Request where
+  type Absence (RequestHeader Required Strict name val) Request = Either HeaderNotFound HeaderParseError
 
-instance Trait (Header Optional Strict name val) Request where
-  type Attribute (Header Optional Strict name val) Request = Maybe val
+instance Trait (RequestHeader Optional Strict name val) Request where
+  type Attribute (RequestHeader Optional Strict name val) Request = Maybe val
 
-instance TraitAbsence (Header Optional Strict name val) Request where
-  type Absence (Header Optional Strict name val) Request = HeaderParseError
+instance TraitAbsence (RequestHeader Optional Strict name val) Request where
+  type Absence (RequestHeader Optional Strict name val) Request = HeaderParseError
 
-instance Trait (Header Required Lenient name val) Request where
-  type Attribute (Header Required Lenient name val) Request = Either Text val
+instance Trait (RequestHeader Required Lenient name val) Request where
+  type Attribute (RequestHeader Required Lenient name val) Request = Either Text val
 
-instance TraitAbsence (Header Required Lenient name val) Request where
-  type Absence (Header Required Lenient name val) Request = HeaderNotFound
+instance TraitAbsence (RequestHeader Required Lenient name val) Request where
+  type Absence (RequestHeader Required Lenient name val) Request = HeaderNotFound
 
-instance Trait (Header Optional Lenient name val) Request where
-  type Attribute (Header Optional Lenient name val) Request = Maybe (Either Text val)
+instance Trait (RequestHeader Optional Lenient name val) Request where
+  type Attribute (RequestHeader Optional Lenient name val) Request = Maybe (Either Text val)
 
-instance TraitAbsence (Header Optional Lenient name val) Request where
-  type Absence (Header Optional Lenient name val) Request = Void
+instance TraitAbsence (RequestHeader Optional Lenient name val) Request where
+  type Absence (RequestHeader Optional Lenient name val) Request = Void
 
 headerHandler ::
   forall name val e p h req.
-  (Get h (Header e p name val) Request, ArrowChoice h) =>
+  (Get h (RequestHeader e p name val) Request, ArrowChoice h) =>
   -- | error handler
-  h (Request `With` req, Absence (Header e p name val) Request) Response ->
-  Middleware h req (Header e p name val : req)
+  h (Request `With` req, Absence (RequestHeader e p name val) Request) Response ->
+  Middleware h req (RequestHeader e p name val : req)
 headerHandler errorHandler nextHandler = proc request -> do
-  result <- probe Header -< request
+  result <- probe RequestHeader -< request
   case result of
     Left err -> errorHandler -< (request, err)
     Right val -> nextHandler -< val
@@ -129,10 +132,10 @@ headerHandler errorHandler nextHandler = proc request -> do
 -}
 header ::
   forall name val h req.
-  (Get h (Header Required Strict name val) Request, ArrowChoice h) =>
+  (Get h (RequestHeader Required Strict name val) Request, ArrowChoice h) =>
   -- | Error handler
   h (Request `With` req, Either HeaderNotFound HeaderParseError) Response ->
-  Middleware h req (Header Required Strict name val : req)
+  Middleware h req (RequestHeader Required Strict name val : req)
 header = headerHandler
 {-# INLINE header #-}
 
@@ -148,10 +151,10 @@ header = headerHandler
 -}
 optionalHeader ::
   forall name val h req.
-  (Get h (Header Optional Strict name val) Request, ArrowChoice h) =>
+  (Get h (RequestHeader Optional Strict name val) Request, ArrowChoice h) =>
   -- | Error handler
   h (Request `With` req, HeaderParseError) Response ->
-  Middleware h req (Header Optional Strict name val : req)
+  Middleware h req (RequestHeader Optional Strict name val : req)
 optionalHeader = headerHandler
 {-# INLINE optionalHeader #-}
 
@@ -167,10 +170,10 @@ optionalHeader = headerHandler
 -}
 lenientHeader ::
   forall name val h req.
-  (Get h (Header Required Lenient name val) Request, ArrowChoice h) =>
+  (Get h (RequestHeader Required Lenient name val) Request, ArrowChoice h) =>
   -- | Error handler
   h (Request `With` req, HeaderNotFound) Response ->
-  Middleware h req (Header Required Lenient name val : req)
+  Middleware h req (RequestHeader Required Lenient name val : req)
 lenientHeader = headerHandler
 {-# INLINE lenientHeader #-}
 
@@ -186,16 +189,29 @@ lenientHeader = headerHandler
 -}
 optionalLenientHeader ::
   forall name val h req.
-  (Get h (Header Optional Lenient name val) Request, ArrowChoice h) =>
-  Middleware h req (Header Optional Lenient name val : req)
+  (Get h (RequestHeader Optional Lenient name val) Request, ArrowChoice h) =>
+  Middleware h req (RequestHeader Optional Lenient name val : req)
 optionalLenientHeader = headerHandler $ arr (absurd . snd)
 {-# INLINE optionalLenientHeader #-}
 
-instance Trait (Header Required Strict name val) Response where
-  type Attribute (Header Required Strict name val) Response = val
+{- | A 'Trait' for setting a header in the HTTP response. It has a
+ specified @name@ and a value of type @val@ which can be converted to
+ a 'ByteString'. The header name is compared case-insensitively. The
+ modifier @e@ determines whether the header is mandatory or optional.
+-}
+data ResponseHeader (e :: Existence) (name :: Symbol) (val :: Type) = ResponseHeader
 
-instance Trait (Header Optional Strict name val) Response where
-  type Attribute (Header Optional Strict name val) Response = Maybe val
+-- | A `Header` that is required in the response
+type RequiredResponseHeader = ResponseHeader Required
+
+-- | A `Header` that is optional in the response
+type OptionalResponseHeader = ResponseHeader Optional
+
+instance Trait (ResponseHeader Required name val) Response where
+  type Attribute (ResponseHeader Required name val) Response = val
+
+instance Trait (ResponseHeader Optional name val) Response where
+  type Attribute (ResponseHeader Optional name val) Response = Maybe val
 
 {- | Set a header value in a response.
 
@@ -205,9 +221,9 @@ instance Trait (Header Optional Strict name val) Response where
 -}
 setHeader ::
   forall name val h res.
-  (Set h (Header Required Strict name val) Response) =>
-  h (Response `With` res, val) (Response `With` (Header Required Strict name val : res))
-setHeader = plant Header
+  (Set h (ResponseHeader Required name val) Response) =>
+  h (Response `With` res, val) (Response `With` (ResponseHeader Required name val : res))
+setHeader = plant ResponseHeader
 {-# INLINE setHeader #-}
 
 {- | Set an optional header value in a response.
@@ -222,7 +238,7 @@ setHeader = plant Header
 -}
 setOptionalHeader ::
   forall name val h res.
-  (Set h (Header Optional Strict name val) Response) =>
-  h (Response `With` res, Maybe val) (Response `With` (Header Optional Strict name val : res))
-setOptionalHeader = plant Header
+  (Set h (ResponseHeader Optional name val) Response) =>
+  h (Response `With` res, Maybe val) (Response `With` (ResponseHeader Optional name val : res))
+setOptionalHeader = plant ResponseHeader
 {-# INLINE setOptionalHeader #-}

--- a/webgear-core/src/WebGear/Core/Trait/Header.hs
+++ b/webgear-core/src/WebGear/Core/Trait/Header.hs
@@ -204,13 +204,10 @@ instance Trait (Header Optional Strict name val) Response where
  > response' <- setHeader @"Content-Length" -< (response, 42)
 -}
 setHeader ::
-  forall name val a h res.
+  forall name val h res.
   (Set h (Header Required Strict name val) Response) =>
-  h a (Response `With` res) ->
-  h (val, a) (Response `With` (Header Required Strict name val : res))
-setHeader prevHandler = proc (val, a) -> do
-  r <- prevHandler -< a
-  plant Header -< (r, val)
+  h (Response `With` res, val) (Response `With` (Header Required Strict name val : res))
+setHeader = plant Header
 {-# INLINE setHeader #-}
 
 {- | Set an optional header value in a response.
@@ -224,11 +221,8 @@ setHeader prevHandler = proc (val, a) -> do
  > response' <- setOptionalHeader @"Content-Length" -< (response, Just 42)
 -}
 setOptionalHeader ::
-  forall name val a h res.
+  forall name val h res.
   (Set h (Header Optional Strict name val) Response) =>
-  h a (Response `With` res) ->
-  h (Maybe val, a) (Response `With` (Header Optional Strict name val : res))
-setOptionalHeader prevHandler = proc (val, a) -> do
-  r <- prevHandler -< a
-  plant Header -< (r, val)
+  h (Response `With` res, Maybe val) (Response `With` (Header Optional Strict name val : res))
+setOptionalHeader = plant Header
 {-# INLINE setOptionalHeader #-}

--- a/webgear-core/src/WebGear/Core/Trait/QueryParam.hs
+++ b/webgear-core/src/WebGear/Core/Trait/QueryParam.hs
@@ -43,7 +43,7 @@ import WebGear.Core.Handler (Middleware)
 import WebGear.Core.Modifiers (Existence (..), ParseStyle (..))
 import WebGear.Core.Request (Request)
 import WebGear.Core.Response (Response)
-import WebGear.Core.Trait (Get, Linked, Trait (..), TraitAbsence (..), probe)
+import WebGear.Core.Trait (Get, Trait (..), TraitAbsence (..), With, probe)
 
 {- | Capture a query parameter with a specified @name@ and convert it to
  a value of type @val@. The type parameter @e@ denotes whether the
@@ -94,7 +94,7 @@ instance TraitAbsence (QueryParam Optional Lenient name val) Request where
 queryParamHandler ::
   forall name val e p h req.
   (Get h (QueryParam e p name val) Request, ArrowChoice h) =>
-  h (Linked req Request, Absence (QueryParam e p name val) Request) Response ->
+  h (Request `With` req, Absence (QueryParam e p name val) Request) Response ->
   Middleware h req (QueryParam e p name val : req)
 queryParamHandler errorHandler nextHandler = proc request -> do
   result <- probe QueryParam -< request
@@ -115,7 +115,7 @@ queryParamHandler errorHandler nextHandler = proc request -> do
 queryParam ::
   forall name val h req.
   (Get h (QueryParam Required Strict name val) Request, ArrowChoice h) =>
-  h (Linked req Request, Either ParamNotFound ParamParseError) Response ->
+  h (Request `With` req, Either ParamNotFound ParamParseError) Response ->
   Middleware h req (QueryParam Required Strict name val : req)
 queryParam = queryParamHandler
 {-# INLINE queryParam #-}
@@ -133,7 +133,7 @@ queryParam = queryParamHandler
 optionalQueryParam ::
   forall name val h req.
   (Get h (QueryParam Optional Strict name val) Request, ArrowChoice h) =>
-  h (Linked req Request, ParamParseError) Response ->
+  h (Request `With` req, ParamParseError) Response ->
   Middleware h req (QueryParam Optional Strict name val : req)
 optionalQueryParam = queryParamHandler
 {-# INLINE optionalQueryParam #-}
@@ -151,7 +151,7 @@ optionalQueryParam = queryParamHandler
 lenientQueryParam ::
   forall name val h req.
   (Get h (QueryParam Required Lenient name val) Request, ArrowChoice h) =>
-  h (Linked req Request, ParamNotFound) Response ->
+  h (Request `With` req, ParamNotFound) Response ->
   Middleware h req (QueryParam Required Lenient name val : req)
 lenientQueryParam = queryParamHandler
 {-# INLINE lenientQueryParam #-}

--- a/webgear-core/src/WebGear/Core/Trait/Status.hs
+++ b/webgear-core/src/WebGear/Core/Trait/Status.hs
@@ -54,7 +54,7 @@ module WebGear.Core.Trait.Status (
 
 import qualified Network.HTTP.Types as HTTP
 import WebGear.Core.Response (Response (..))
-import WebGear.Core.Trait (Linked, Set, Trait (..), linkzero, plant)
+import WebGear.Core.Trait (Set, Trait (..), With, plant, wzero)
 
 -- | HTTP response status
 newtype Status = Status HTTP.Status
@@ -63,238 +63,238 @@ instance Trait Status Response where
   type Attribute Status Response = HTTP.Status
 
 -- | Generate a response with the specified status
-mkResponse :: Set h Status Response => HTTP.Status -> h () (Linked '[Status] Response)
+mkResponse :: (Set h Status Response) => HTTP.Status -> h () (Response `With` '[Status])
 mkResponse status = proc () -> do
-  let response = linkzero $ Response status [] Nothing
+  let response = wzero $ Response status [] Nothing
   plant (Status status) -< (response, status)
 {-# INLINE mkResponse #-}
 
 -- | Continue 100 response
-continue100 :: Set h Status Response => h () (Linked '[Status] Response)
+continue100 :: (Set h Status Response) => h () (Response `With` '[Status])
 continue100 = mkResponse HTTP.continue100
 {-# INLINE continue100 #-}
 
 -- | Switching Protocols 101 response
-switchingProtocols101 :: Set h Status Response => h () (Linked '[Status] Response)
+switchingProtocols101 :: (Set h Status Response) => h () (Response `With` '[Status])
 switchingProtocols101 = mkResponse HTTP.switchingProtocols101
 {-# INLINE switchingProtocols101 #-}
 
 -- | OK 200 response
-ok200 :: Set h Status Response => h () (Linked '[Status] Response)
+ok200 :: (Set h Status Response) => h () (Response `With` '[Status])
 ok200 = mkResponse HTTP.ok200
 {-# INLINE ok200 #-}
 
 -- | Created 201 response
-created201 :: Set h Status Response => h () (Linked '[Status] Response)
+created201 :: (Set h Status Response) => h () (Response `With` '[Status])
 created201 = mkResponse HTTP.created201
 {-# INLINE created201 #-}
 
 -- | Accepted 202 response
-accepted202 :: Set h Status Response => h () (Linked '[Status] Response)
+accepted202 :: (Set h Status Response) => h () (Response `With` '[Status])
 accepted202 = mkResponse HTTP.accepted202
 {-# INLINE accepted202 #-}
 
 -- | Non-Authoritative 203 response
-nonAuthoritative203 :: Set h Status Response => h () (Linked '[Status] Response)
+nonAuthoritative203 :: (Set h Status Response) => h () (Response `With` '[Status])
 nonAuthoritative203 = mkResponse HTTP.nonAuthoritative203
 {-# INLINE nonAuthoritative203 #-}
 
 -- | No Content 204 response
-noContent204 :: Set h Status Response => h () (Linked '[Status] Response)
+noContent204 :: (Set h Status Response) => h () (Response `With` '[Status])
 noContent204 = mkResponse HTTP.noContent204
 {-# INLINE noContent204 #-}
 
 -- | Reset Content 205 response
-resetContent205 :: Set h Status Response => h () (Linked '[Status] Response)
+resetContent205 :: (Set h Status Response) => h () (Response `With` '[Status])
 resetContent205 = mkResponse HTTP.resetContent205
 {-# INLINE resetContent205 #-}
 
 -- | Partial Content 206 response
-partialContent206 :: Set h Status Response => h () (Linked '[Status] Response)
+partialContent206 :: (Set h Status Response) => h () (Response `With` '[Status])
 partialContent206 = mkResponse HTTP.partialContent206
 {-# INLINE partialContent206 #-}
 
 -- | Multiple Choices 300 response
-multipleChoices300 :: Set h Status Response => h () (Linked '[Status] Response)
+multipleChoices300 :: (Set h Status Response) => h () (Response `With` '[Status])
 multipleChoices300 = mkResponse HTTP.multipleChoices300
 {-# INLINE multipleChoices300 #-}
 
 -- | Moved Permanently 301 response
-movedPermanently301 :: Set h Status Response => h () (Linked '[Status] Response)
+movedPermanently301 :: (Set h Status Response) => h () (Response `With` '[Status])
 movedPermanently301 = mkResponse HTTP.movedPermanently301
 {-# INLINE movedPermanently301 #-}
 
 -- | Found 302 response
-found302 :: Set h Status Response => h () (Linked '[Status] Response)
+found302 :: (Set h Status Response) => h () (Response `With` '[Status])
 found302 = mkResponse HTTP.found302
 {-# INLINE found302 #-}
 
 -- | See Other 303 response
-seeOther303 :: Set h Status Response => h () (Linked '[Status] Response)
+seeOther303 :: (Set h Status Response) => h () (Response `With` '[Status])
 seeOther303 = mkResponse HTTP.seeOther303
 {-# INLINE seeOther303 #-}
 
 -- | Not Modified 304 response
-notModified304 :: Set h Status Response => h () (Linked '[Status] Response)
+notModified304 :: (Set h Status Response) => h () (Response `With` '[Status])
 notModified304 = mkResponse HTTP.notModified304
 {-# INLINE notModified304 #-}
 
 -- | Temporary Redirect 307 response
-temporaryRedirect307 :: Set h Status Response => h () (Linked '[Status] Response)
+temporaryRedirect307 :: (Set h Status Response) => h () (Response `With` '[Status])
 temporaryRedirect307 = mkResponse HTTP.temporaryRedirect307
 {-# INLINE temporaryRedirect307 #-}
 
 -- | Permanent Redirect 308 response
-permanentRedirect308 :: Set h Status Response => h () (Linked '[Status] Response)
+permanentRedirect308 :: (Set h Status Response) => h () (Response `With` '[Status])
 permanentRedirect308 = mkResponse HTTP.permanentRedirect308
 {-# INLINE permanentRedirect308 #-}
 
 -- | Bad Request 400 response
-badRequest400 :: Set h Status Response => h () (Linked '[Status] Response)
+badRequest400 :: (Set h Status Response) => h () (Response `With` '[Status])
 badRequest400 = mkResponse HTTP.badRequest400
 {-# INLINE badRequest400 #-}
 
 -- | Unauthorized 401 response
-unauthorized401 :: Set h Status Response => h () (Linked '[Status] Response)
+unauthorized401 :: (Set h Status Response) => h () (Response `With` '[Status])
 unauthorized401 = mkResponse HTTP.unauthorized401
 {-# INLINE unauthorized401 #-}
 
 -- | Payment Required 402 response
-paymentRequired402 :: Set h Status Response => h () (Linked '[Status] Response)
+paymentRequired402 :: (Set h Status Response) => h () (Response `With` '[Status])
 paymentRequired402 = mkResponse HTTP.paymentRequired402
 {-# INLINE paymentRequired402 #-}
 
 -- | Forbidden 403 response
-forbidden403 :: Set h Status Response => h () (Linked '[Status] Response)
+forbidden403 :: (Set h Status Response) => h () (Response `With` '[Status])
 forbidden403 = mkResponse HTTP.forbidden403
 {-# INLINE forbidden403 #-}
 
 -- | Not Found 404 response
-notFound404 :: Set h Status Response => h () (Linked '[Status] Response)
+notFound404 :: (Set h Status Response) => h () (Response `With` '[Status])
 notFound404 = mkResponse HTTP.notFound404
 {-# INLINE notFound404 #-}
 
 -- | Method Not Allowed 405 response
-methodNotAllowed405 :: Set h Status Response => h () (Linked '[Status] Response)
+methodNotAllowed405 :: (Set h Status Response) => h () (Response `With` '[Status])
 methodNotAllowed405 = mkResponse HTTP.methodNotAllowed405
 {-# INLINE methodNotAllowed405 #-}
 
 -- | Not Acceptable 406 response
-notAcceptable406 :: Set h Status Response => h () (Linked '[Status] Response)
+notAcceptable406 :: (Set h Status Response) => h () (Response `With` '[Status])
 notAcceptable406 = mkResponse HTTP.notAcceptable406
 {-# INLINE notAcceptable406 #-}
 
 -- | Proxy Authentication Required 407 response
-proxyAuthenticationRequired407 :: Set h Status Response => h () (Linked '[Status] Response)
+proxyAuthenticationRequired407 :: (Set h Status Response) => h () (Response `With` '[Status])
 proxyAuthenticationRequired407 = mkResponse HTTP.proxyAuthenticationRequired407
 {-# INLINE proxyAuthenticationRequired407 #-}
 
 -- | Request Timeout 408 response
-requestTimeout408 :: Set h Status Response => h () (Linked '[Status] Response)
+requestTimeout408 :: (Set h Status Response) => h () (Response `With` '[Status])
 requestTimeout408 = mkResponse HTTP.requestTimeout408
 {-# INLINE requestTimeout408 #-}
 
 -- | Conflict 409 response
-conflict409 :: Set h Status Response => h () (Linked '[Status] Response)
+conflict409 :: (Set h Status Response) => h () (Response `With` '[Status])
 conflict409 = mkResponse HTTP.conflict409
 {-# INLINE conflict409 #-}
 
 -- | Gone 410 response
-gone410 :: Set h Status Response => h () (Linked '[Status] Response)
+gone410 :: (Set h Status Response) => h () (Response `With` '[Status])
 gone410 = mkResponse HTTP.gone410
 {-# INLINE gone410 #-}
 
 -- | Length Required 411 response
-lengthRequired411 :: Set h Status Response => h () (Linked '[Status] Response)
+lengthRequired411 :: (Set h Status Response) => h () (Response `With` '[Status])
 lengthRequired411 = mkResponse HTTP.lengthRequired411
 {-# INLINE lengthRequired411 #-}
 
 -- | Precondition Failed 412 response
-preconditionFailed412 :: Set h Status Response => h () (Linked '[Status] Response)
+preconditionFailed412 :: (Set h Status Response) => h () (Response `With` '[Status])
 preconditionFailed412 = mkResponse HTTP.preconditionFailed412
 {-# INLINE preconditionFailed412 #-}
 
 -- | Request Entity Too Large 413 response
-requestEntityTooLarge413 :: Set h Status Response => h () (Linked '[Status] Response)
+requestEntityTooLarge413 :: (Set h Status Response) => h () (Response `With` '[Status])
 requestEntityTooLarge413 = mkResponse HTTP.requestEntityTooLarge413
 {-# INLINE requestEntityTooLarge413 #-}
 
 -- | Request URI Too Long 414 response
-requestURITooLong414 :: Set h Status Response => h () (Linked '[Status] Response)
+requestURITooLong414 :: (Set h Status Response) => h () (Response `With` '[Status])
 requestURITooLong414 = mkResponse HTTP.requestURITooLong414
 {-# INLINE requestURITooLong414 #-}
 
 -- | Unsupported Media Type 415 response
-unsupportedMediaType415 :: Set h Status Response => h () (Linked '[Status] Response)
+unsupportedMediaType415 :: (Set h Status Response) => h () (Response `With` '[Status])
 unsupportedMediaType415 = mkResponse HTTP.unsupportedMediaType415
 {-# INLINE unsupportedMediaType415 #-}
 
 -- | Requested Range Not Satisfiable 416 response
-requestedRangeNotSatisfiable416 :: Set h Status Response => h () (Linked '[Status] Response)
+requestedRangeNotSatisfiable416 :: (Set h Status Response) => h () (Response `With` '[Status])
 requestedRangeNotSatisfiable416 = mkResponse HTTP.requestedRangeNotSatisfiable416
 {-# INLINE requestedRangeNotSatisfiable416 #-}
 
 -- | Expectation Failed 417 response
-expectationFailed417 :: Set h Status Response => h () (Linked '[Status] Response)
+expectationFailed417 :: (Set h Status Response) => h () (Response `With` '[Status])
 expectationFailed417 = mkResponse HTTP.expectationFailed417
 {-# INLINE expectationFailed417 #-}
 
 -- | I'm A Teapot 418 response
-imATeapot418 :: Set h Status Response => h () (Linked '[Status] Response)
+imATeapot418 :: (Set h Status Response) => h () (Response `With` '[Status])
 imATeapot418 = mkResponse HTTP.imATeapot418
 {-# INLINE imATeapot418 #-}
 
 -- | Unprocessable Entity 422 response
-unprocessableEntity422 :: Set h Status Response => h () (Linked '[Status] Response)
+unprocessableEntity422 :: (Set h Status Response) => h () (Response `With` '[Status])
 unprocessableEntity422 = mkResponse HTTP.unprocessableEntity422
 {-# INLINE unprocessableEntity422 #-}
 
 -- | Precondition Required 428 response
-preconditionRequired428 :: Set h Status Response => h () (Linked '[Status] Response)
+preconditionRequired428 :: (Set h Status Response) => h () (Response `With` '[Status])
 preconditionRequired428 = mkResponse HTTP.preconditionRequired428
 {-# INLINE preconditionRequired428 #-}
 
 -- | Too Many Requests 429 response
-tooManyRequests429 :: Set h Status Response => h () (Linked '[Status] Response)
+tooManyRequests429 :: (Set h Status Response) => h () (Response `With` '[Status])
 tooManyRequests429 = mkResponse HTTP.tooManyRequests429
 {-# INLINE tooManyRequests429 #-}
 
 -- | Request Header Fields Too Large 431 response
-requestHeaderFieldsTooLarge431 :: Set h Status Response => h () (Linked '[Status] Response)
+requestHeaderFieldsTooLarge431 :: (Set h Status Response) => h () (Response `With` '[Status])
 requestHeaderFieldsTooLarge431 = mkResponse HTTP.requestHeaderFieldsTooLarge431
 {-# INLINE requestHeaderFieldsTooLarge431 #-}
 
 -- | Internal Server Error 500 response
-internalServerError500 :: Set h Status Response => h () (Linked '[Status] Response)
+internalServerError500 :: (Set h Status Response) => h () (Response `With` '[Status])
 internalServerError500 = mkResponse HTTP.internalServerError500
 {-# INLINE internalServerError500 #-}
 
 -- | Not Implemented 501 response
-notImplemented501 :: Set h Status Response => h () (Linked '[Status] Response)
+notImplemented501 :: (Set h Status Response) => h () (Response `With` '[Status])
 notImplemented501 = mkResponse HTTP.notImplemented501
 {-# INLINE notImplemented501 #-}
 
 -- | Bad Gateway 502 response
-badGateway502 :: Set h Status Response => h () (Linked '[Status] Response)
+badGateway502 :: (Set h Status Response) => h () (Response `With` '[Status])
 badGateway502 = mkResponse HTTP.badGateway502
 {-# INLINE badGateway502 #-}
 
 -- | Service Unavailable 503 response
-serviceUnavailable503 :: Set h Status Response => h () (Linked '[Status] Response)
+serviceUnavailable503 :: (Set h Status Response) => h () (Response `With` '[Status])
 serviceUnavailable503 = mkResponse HTTP.serviceUnavailable503
 {-# INLINE serviceUnavailable503 #-}
 
 -- | Gateway Timeout 504 response
-gatewayTimeout504 :: Set h Status Response => h () (Linked '[Status] Response)
+gatewayTimeout504 :: (Set h Status Response) => h () (Response `With` '[Status])
 gatewayTimeout504 = mkResponse HTTP.gatewayTimeout504
 {-# INLINE gatewayTimeout504 #-}
 
 -- | HTTP Version Not Supported 505 response
-httpVersionNotSupported505 :: Set h Status Response => h () (Linked '[Status] Response)
+httpVersionNotSupported505 :: (Set h Status Response) => h () (Response `With` '[Status])
 httpVersionNotSupported505 = mkResponse HTTP.httpVersionNotSupported505
 {-# INLINE httpVersionNotSupported505 #-}
 
 -- | Network Authentication Required 511 response
-networkAuthenticationRequired511 :: Set h Status Response => h () (Linked '[Status] Response)
+networkAuthenticationRequired511 :: (Set h Status Response) => h () (Response `With` '[Status])
 networkAuthenticationRequired511 = mkResponse HTTP.networkAuthenticationRequired511
 {-# INLINE networkAuthenticationRequired511 #-}

--- a/webgear-core/src/WebGear/Core/Traits.hs
+++ b/webgear-core/src/WebGear/Core/Traits.hs
@@ -26,18 +26,15 @@ import WebGear.Core.Trait.Path
 import WebGear.Core.Trait.QueryParam
 import WebGear.Core.Trait.Status
 
-{- | Constraints that include all common traits.
+{- | Constraints that include a set of common traits for handlers.
 
  The type variables are:
 
  * @h@ - The handler arrow
  * @m@ - The underlying monad of the handler
- * @req@ - List of traits the handler `Gets` from the request
- * @res@ - List of traits the handler `Sets` on the response
 -}
-type StdHandler h m req res =
+type StdHandler h m =
   ( Handler h m
   , Gets h [Method, Path, PathEnd] Request
-  , Gets h req Request
-  , Sets h (Status : res) Response
+  , Sets h '[Status] Response
   )

--- a/webgear-openapi/src/WebGear/OpenApi/Handler.hs
+++ b/webgear-openapi/src/WebGear/OpenApi/Handler.hs
@@ -251,7 +251,7 @@ combinePathItem s t =
 
 combineOpenApi :: OpenApi -> OpenApi -> OpenApi
 combineOpenApi s t =
-  OpenApi
+  (mempty @OpenApi)
     { _openApiInfo = _openApiInfo s <> _openApiInfo t
     , _openApiServers = _openApiServers s <> _openApiServers t
     , _openApiPaths = Map.unionWith combinePathItem (_openApiPaths s) (_openApiPaths t)

--- a/webgear-openapi/src/WebGear/OpenApi/Trait/Auth/Basic.hs
+++ b/webgear-openapi/src/WebGear/OpenApi/Trait/Auth/Basic.hs
@@ -8,7 +8,7 @@ import Data.Proxy (Proxy (..))
 import Data.String (fromString)
 import GHC.TypeLits (KnownSymbol, symbolVal)
 import WebGear.Core.Request (Request)
-import WebGear.Core.Trait (Attribute, Get (..), Linked, TraitAbsence (Absence))
+import WebGear.Core.Trait (Attribute, Get (..), TraitAbsence (Absence), With)
 import WebGear.Core.Trait.Auth.Basic (BasicAuth' (..))
 import WebGear.OpenApi.Handler (DocNode (DocSecurityScheme), OpenApiHandler (..), singletonNode)
 
@@ -16,7 +16,7 @@ instance (TraitAbsence (BasicAuth' x scheme m e a) Request, KnownSymbol scheme) 
   {-# INLINE getTrait #-}
   getTrait ::
     BasicAuth' x scheme m e a ->
-    OpenApiHandler m (Linked ts Request) (Either (Absence (BasicAuth' x scheme m e a) Request) (Attribute (BasicAuth' x scheme m e a) Request))
+    OpenApiHandler m (Request `With` ts) (Either (Absence (BasicAuth' x scheme m e a) Request) (Attribute (BasicAuth' x scheme m e a) Request))
   getTrait _ =
     let schemeName = "http" <> fromString (symbolVal (Proxy @scheme))
         securityScheme =

--- a/webgear-openapi/src/WebGear/OpenApi/Trait/Auth/JWT.hs
+++ b/webgear-openapi/src/WebGear/OpenApi/Trait/Auth/JWT.hs
@@ -8,7 +8,7 @@ import Data.String (fromString)
 import Data.Typeable (Proxy (..))
 import GHC.TypeLits (KnownSymbol, symbolVal)
 import WebGear.Core.Request (Request)
-import WebGear.Core.Trait (Attribute, Get (..), Linked, TraitAbsence (..))
+import WebGear.Core.Trait (Attribute, Get (..), TraitAbsence (..), With)
 import WebGear.Core.Trait.Auth.JWT (JWTAuth' (..))
 import WebGear.OpenApi.Handler (DocNode (DocSecurityScheme), OpenApiHandler (..), singletonNode)
 
@@ -19,7 +19,7 @@ instance
   {-# INLINE getTrait #-}
   getTrait ::
     JWTAuth' x scheme m e a ->
-    OpenApiHandler m (Linked ts Request) (Either (Absence (JWTAuth' x scheme m e a) Request) (Attribute (JWTAuth' x scheme m e a) Request))
+    OpenApiHandler m (Request `With` ts) (Either (Absence (JWTAuth' x scheme m e a) Request) (Attribute (JWTAuth' x scheme m e a) Request))
   getTrait _ =
     let schemeName = "http" <> fromString (symbolVal (Proxy @scheme))
         securityScheme =

--- a/webgear-openapi/src/WebGear/OpenApi/Trait/Header.hs
+++ b/webgear-openapi/src/WebGear/OpenApi/Trait/Header.hs
@@ -12,7 +12,7 @@ import GHC.TypeLits (KnownSymbol, symbolVal)
 import WebGear.Core.Modifiers (Existence (..))
 import WebGear.Core.Request (Request)
 import WebGear.Core.Response (Response)
-import WebGear.Core.Trait (Get (..), Set (..), Trait, TraitAbsence)
+import WebGear.Core.Trait (Get (..), Set (..), TraitAbsence)
 import qualified WebGear.Core.Trait.Header as WG
 import WebGear.OpenApi.Handler (DocNode (..), OpenApiHandler (..), nullNode, singletonNode)
 
@@ -30,19 +30,19 @@ mkParam _ _ isRequired =
     & required ?~ isRequired
     & schema ?~ Inline (toSchema $ Proxy @val)
 
-instance (KnownSymbol name, ToSchema val, TraitAbsence (WG.Header Required ps name val) Request) => Get (OpenApiHandler m) (WG.Header Required ps name val) Request where
+instance (KnownSymbol name, ToSchema val, TraitAbsence (WG.RequestHeader Required ps name val) Request) => Get (OpenApiHandler m) (WG.RequestHeader Required ps name val) Request where
   {-# INLINE getTrait #-}
-  getTrait WG.Header =
+  getTrait WG.RequestHeader =
     OpenApiHandler $ singletonNode (DocRequestHeader $ mkParam (Proxy @name) (Proxy @val) True)
 
-instance (KnownSymbol name, ToSchema val, TraitAbsence (WG.Header Optional ps name val) Request) => Get (OpenApiHandler m) (WG.Header Optional ps name val) Request where
+instance (KnownSymbol name, ToSchema val, TraitAbsence (WG.RequestHeader Optional ps name val) Request) => Get (OpenApiHandler m) (WG.RequestHeader Optional ps name val) Request where
   {-# INLINE getTrait #-}
-  getTrait WG.Header =
+  getTrait WG.RequestHeader =
     OpenApiHandler $ singletonNode (DocRequestHeader $ mkParam (Proxy @name) (Proxy @val) False)
 
-instance (KnownSymbol name, ToSchema val, Trait (WG.Header Required ps name val) Response) => Set (OpenApiHandler m) (WG.Header Required ps name val) Response where
+instance (KnownSymbol name, ToSchema val) => Set (OpenApiHandler m) (WG.ResponseHeader Required name val) Response where
   {-# INLINE setTrait #-}
-  setTrait WG.Header _ =
+  setTrait WG.ResponseHeader _ =
     let headerName = fromString $ symbolVal $ Proxy @name
         header =
           mempty @Header
@@ -52,9 +52,9 @@ instance (KnownSymbol name, ToSchema val, Trait (WG.Header Required ps name val)
           then OpenApiHandler nullNode
           else OpenApiHandler $ singletonNode (DocResponseHeader headerName header)
 
-instance (KnownSymbol name, ToSchema val, Trait (WG.Header Optional ps name val) Response) => Set (OpenApiHandler m) (WG.Header Optional ps name val) Response where
+instance (KnownSymbol name, ToSchema val) => Set (OpenApiHandler m) (WG.ResponseHeader Optional name val) Response where
   {-# INLINE setTrait #-}
-  setTrait WG.Header _ =
+  setTrait WG.ResponseHeader _ =
     let headerName = fromString $ symbolVal $ Proxy @name
         header =
           mempty @Header

--- a/webgear-openapi/src/WebGear/OpenApi/Trait/Path.hs
+++ b/webgear-openapi/src/WebGear/OpenApi/Trait/Path.hs
@@ -8,7 +8,7 @@ import Data.OpenApi (Param (..), ParamLocation (ParamPath), Referenced (Inline),
 import Data.String (fromString)
 import GHC.TypeLits (KnownSymbol, symbolVal)
 import WebGear.Core.Request (Request)
-import WebGear.Core.Trait (Get (..), Linked)
+import WebGear.Core.Trait (Get (..), With)
 import WebGear.Core.Trait.Path (Path (..), PathEnd (..), PathVar (..), PathVarError (..))
 import WebGear.OpenApi.Handler (
   DocNode (DocPathElem, DocPathVar),
@@ -18,12 +18,12 @@ import WebGear.OpenApi.Handler (
 
 instance Get (OpenApiHandler m) Path Request where
   {-# INLINE getTrait #-}
-  getTrait :: Path -> OpenApiHandler m (Linked ts Request) (Either () ())
+  getTrait :: Path -> OpenApiHandler m (Request `With` ts) (Either () ())
   getTrait (Path p) = OpenApiHandler $ singletonNode (DocPathElem p)
 
 instance (KnownSymbol tag, ToSchema val) => Get (OpenApiHandler m) (PathVar tag val) Request where
   {-# INLINE getTrait #-}
-  getTrait :: PathVar tag val -> OpenApiHandler m (Linked ts Request) (Either PathVarError val)
+  getTrait :: PathVar tag val -> OpenApiHandler m (Request `With` ts) (Either PathVarError val)
   getTrait PathVar =
     let param =
           (mempty :: Param)
@@ -36,5 +36,5 @@ instance (KnownSymbol tag, ToSchema val) => Get (OpenApiHandler m) (PathVar tag 
 
 instance Get (OpenApiHandler m) PathEnd Request where
   {-# INLINE getTrait #-}
-  getTrait :: PathEnd -> OpenApiHandler m (Linked ts Request) (Either () ())
+  getTrait :: PathEnd -> OpenApiHandler m (Request `With` ts) (Either () ())
   getTrait PathEnd = OpenApiHandler $ singletonNode (DocPathElem "/")

--- a/webgear-openapi/src/WebGear/OpenApi/Trait/Status.hs
+++ b/webgear-openapi/src/WebGear/OpenApi/Trait/Status.hs
@@ -5,7 +5,7 @@ module WebGear.OpenApi.Trait.Status where
 
 import qualified Network.HTTP.Types as HTTP
 import WebGear.Core.Response (Response)
-import WebGear.Core.Trait (Linked, Set, setTrait)
+import WebGear.Core.Trait (Set, With, setTrait)
 import WebGear.Core.Trait.Status (Status (..))
 import WebGear.OpenApi.Handler (DocNode (DocStatus), OpenApiHandler (..), singletonNode)
 
@@ -13,6 +13,6 @@ instance Set (OpenApiHandler m) Status Response where
   {-# INLINE setTrait #-}
   setTrait ::
     Status ->
-    (Linked ts Response -> Response -> HTTP.Status -> Linked (Status : ts) Response) ->
-    OpenApiHandler m (Linked ts Response, HTTP.Status) (Linked (Status : ts) Response)
+    (Response `With` ts -> Response -> HTTP.Status -> Response `With` (Status : ts)) ->
+    OpenApiHandler m (Response `With` ts, HTTP.Status) (Response `With` (Status : ts))
   setTrait (Status status) _ = OpenApiHandler $ singletonNode (DocStatus status)

--- a/webgear-server/src/WebGear/Server/Trait/Auth/Basic.hs
+++ b/webgear-server/src/WebGear/Server/Trait/Auth/Basic.hs
@@ -12,7 +12,7 @@ import Data.Void (Void)
 import WebGear.Core.Handler (arrM)
 import WebGear.Core.Modifiers
 import WebGear.Core.Request (Request)
-import WebGear.Core.Trait (Get (..), Linked)
+import WebGear.Core.Trait (Get (..), With)
 import WebGear.Core.Trait.Auth.Basic (
   BasicAuth' (..),
   BasicAuthError (..),
@@ -36,7 +36,7 @@ instance
   {-# INLINE getTrait #-}
   getTrait ::
     BasicAuth' Required scheme m e a ->
-    ServerHandler m (Linked ts Request) (Either (BasicAuthError e) a)
+    ServerHandler m (Request `With` ts) (Either (BasicAuthError e) a)
   getTrait BasicAuth'{..} = proc request -> do
     result <- getAuthorizationHeaderTrait @scheme -< request
     case result of
@@ -67,5 +67,5 @@ instance
   {-# INLINE getTrait #-}
   getTrait ::
     BasicAuth' Optional scheme m e a ->
-    ServerHandler m (Linked ts Request) (Either Void (Either (BasicAuthError e) a))
+    ServerHandler m (Request `With` ts) (Either Void (Either (BasicAuthError e) a))
   getTrait BasicAuth'{..} = getTrait (BasicAuth'{..} :: BasicAuth' Required scheme m e a) >>> arr Right

--- a/webgear-server/src/WebGear/Server/Trait/Auth/JWT.hs
+++ b/webgear-server/src/WebGear/Server/Trait/Auth/JWT.hs
@@ -14,7 +14,7 @@ import Data.Void (Void)
 import WebGear.Core.Handler (arrM)
 import WebGear.Core.Modifiers
 import WebGear.Core.Request (Request)
-import WebGear.Core.Trait (Get (..), Linked)
+import WebGear.Core.Trait (Get (..), With)
 import WebGear.Core.Trait.Auth.Common (
   AuthToken (..),
   AuthorizationHeader,
@@ -27,7 +27,7 @@ instance (MonadTime m, Get (ServerHandler m) (AuthorizationHeader scheme) Reques
   {-# INLINE getTrait #-}
   getTrait ::
     JWTAuth' Required scheme m e a ->
-    ServerHandler m (Linked ts Request) (Either (JWTAuthError e) a)
+    ServerHandler m (Request `With` ts) (Either (JWTAuthError e) a)
   getTrait JWTAuth'{..} = proc request -> do
     result <- getAuthorizationHeaderTrait @scheme -< request
     case result of
@@ -50,5 +50,5 @@ instance (MonadTime m, Get (ServerHandler m) (AuthorizationHeader scheme) Reques
   {-# INLINE getTrait #-}
   getTrait ::
     JWTAuth' Optional scheme m e a ->
-    ServerHandler m (Linked ts Request) (Either Void (Either (JWTAuthError e) a))
+    ServerHandler m (Request `With` ts) (Either Void (Either (JWTAuthError e) a))
   getTrait JWTAuth'{..} = getTrait (JWTAuth'{..} :: JWTAuth' Required scheme m e a) >>> arr Right

--- a/webgear-server/src/WebGear/Server/Trait/Method.hs
+++ b/webgear-server/src/WebGear/Server/Trait/Method.hs
@@ -6,16 +6,16 @@ module WebGear.Server.Trait.Method where
 import Control.Arrow (returnA)
 import qualified Network.HTTP.Types as HTTP
 import WebGear.Core.Request (Request, requestMethod)
-import WebGear.Core.Trait (Get (..), Linked, unlink)
+import WebGear.Core.Trait (Get (..), With (unwitness), unwitness)
 import WebGear.Core.Trait.Method (Method (..), MethodMismatch (..))
 import WebGear.Server.Handler (ServerHandler)
 
-instance Monad m => Get (ServerHandler m) Method Request where
+instance (Monad m) => Get (ServerHandler m) Method Request where
   {-# INLINE getTrait #-}
-  getTrait :: Method -> ServerHandler m (Linked ts Request) (Either MethodMismatch HTTP.StdMethod)
+  getTrait :: Method -> ServerHandler m (Request `With` ts) (Either MethodMismatch HTTP.StdMethod)
   getTrait (Method method) = proc request -> do
     let expectedMethod = HTTP.renderStdMethod method
-        actualMethod = requestMethod $ unlink request
+        actualMethod = requestMethod $ unwitness request
     if actualMethod == expectedMethod
       then returnA -< Right method
       else returnA -< Left $ MethodMismatch{..}

--- a/webgear-server/src/WebGear/Server/Trait/Status.hs
+++ b/webgear-server/src/WebGear/Server/Trait/Status.hs
@@ -6,17 +6,16 @@ module WebGear.Server.Trait.Status where
 import Control.Arrow (returnA)
 import qualified Network.HTTP.Types.Status as HTTP
 import WebGear.Core.Response (Response (responseStatus))
-import WebGear.Core.Trait (Linked, Set, setTrait, unlink)
+import WebGear.Core.Trait (Set, With, setTrait, unwitness)
 import WebGear.Core.Trait.Status (Status (..))
 import WebGear.Server.Handler (ServerHandler)
 
-instance Monad m => Set (ServerHandler m) Status Response where
+instance (Monad m) => Set (ServerHandler m) Status Response where
   {-# INLINE setTrait #-}
   setTrait ::
     Status ->
-    (Linked ts Response -> Response -> HTTP.Status -> Linked (Status : ts) Response) ->
-    ServerHandler m (Linked ts Response, HTTP.Status) (Linked (Status : ts) Response)
-  setTrait (Status status) f = proc (linkedResponse, _) -> do
-    let response = unlink linkedResponse
-        response' = response{responseStatus = status}
-    returnA -< f linkedResponse response' status
+    (Response `With` ts -> Response -> HTTP.Status -> Response `With` (Status : ts)) ->
+    ServerHandler m (Response `With` ts, HTTP.Status) (Response `With` (Status : ts))
+  setTrait (Status status) f = proc (response, _) -> do
+    let response' = (unwitness response){responseStatus = status}
+    returnA -< f response response' status

--- a/webgear-server/test/Properties/Trait/Auth/Basic.hs
+++ b/webgear-server/test/Properties/Trait/Auth/Basic.hs
@@ -30,7 +30,7 @@ import WebGear.Core.Trait.Auth.Basic (
   Username (..),
  )
 import WebGear.Core.Trait.Auth.Common (AuthorizationHeader)
-import WebGear.Core.Trait.Header (Header (..))
+import WebGear.Core.Trait.Header (RequestHeader (..))
 import WebGear.Server.Handler (ServerHandler, runServerHandler)
 import WebGear.Server.Trait.Auth.Basic ()
 import WebGear.Server.Trait.Header ()
@@ -47,7 +47,7 @@ prop_basicAuth = property f
               mkRequest :: ServerHandler Identity () (Request `With` '[AuthorizationHeader "Basic"])
               mkRequest = proc () -> do
                 let req = Request $ defaultRequest{requestHeaders = [("Authorization", hval)]}
-                r <- probe Header -< wzero req
+                r <- probe RequestHeader -< wzero req
                 returnA -< fromRight undefined r
 
               authCfg :: BasicAuth Identity () Credentials

--- a/webgear-server/test/Properties/Trait/Body.hs
+++ b/webgear-server/test/Properties/Trait/Body.hs
@@ -14,7 +14,7 @@ import Test.QuickCheck.Monadic (assert, monadicIO, monitor)
 import Test.Tasty (TestTree)
 import Test.Tasty.QuickCheck (testProperties)
 import WebGear.Core.Request (Request (..))
-import WebGear.Core.Trait (Linked, getTrait, linkzero)
+import WebGear.Core.Trait (With, getTrait, wzero)
 import WebGear.Core.Trait.Body (JSONBody (..))
 import WebGear.Server.Handler (runServerHandler)
 import WebGear.Server.Trait.Body ()
@@ -22,11 +22,11 @@ import WebGear.Server.Trait.Body ()
 jsonBody :: JSONBody t
 jsonBody = JSONBody (Just "application/json")
 
-bodyToRequest :: (MonadIO m, Show a) => a -> m (Linked '[] Request)
+bodyToRequest :: (MonadIO m, Show a) => a -> m (Request `With` '[])
 bodyToRequest x = do
   body <- liftIO $ newIORef $ Just $ fromString $ show x
   let f = readIORef body >>= maybe (pure "") (\s -> writeIORef body Nothing >> pure s)
-  return $ linkzero $ Request $ defaultRequest{requestBody = f}
+  return $ wzero $ Request $ defaultRequest{requestBody = f}
 
 prop_emptyRequestBodyFails :: Property
 prop_emptyRequestBodyFails = monadicIO $ do

--- a/webgear-server/test/Properties/Trait/Header.hs
+++ b/webgear-server/test/Properties/Trait/Header.hs
@@ -11,7 +11,7 @@ import Test.QuickCheck.Instances ()
 import Test.Tasty (TestTree)
 import Test.Tasty.QuickCheck (testProperties)
 import WebGear.Core.Request (Request (..))
-import WebGear.Core.Trait (getTrait, linkzero)
+import WebGear.Core.Trait (getTrait, wzero)
 import WebGear.Core.Trait.Header (Header (..), HeaderParseError (..), RequiredHeader)
 import WebGear.Server.Handler (runServerHandler)
 import WebGear.Server.Trait.Header ()
@@ -19,7 +19,7 @@ import WebGear.Server.Trait.Header ()
 prop_headerParseError :: Property
 prop_headerParseError = property $ \hval ->
   let hval' = "test-" <> hval
-      req = linkzero $ Request $ defaultRequest{requestHeaders = [("foo", encodeUtf8 hval')]}
+      req = wzero $ Request $ defaultRequest{requestHeaders = [("foo", encodeUtf8 hval')]}
    in runIdentity $ do
         res <- runServerHandler (getTrait (Header :: RequiredHeader "foo" Int)) [""] req
         pure $ case res of
@@ -29,7 +29,7 @@ prop_headerParseError = property $ \hval ->
 
 prop_headerParseSuccess :: Property
 prop_headerParseSuccess = property $ \(n :: Int) ->
-  let req = linkzero $ Request $ defaultRequest{requestHeaders = [("foo", fromString $ show n)]}
+  let req = wzero $ Request $ defaultRequest{requestHeaders = [("foo", fromString $ show n)]}
    in runIdentity $ do
         res <- runServerHandler (getTrait (Header :: RequiredHeader "foo" Int)) [""] req
         pure $ case res of

--- a/webgear-server/test/Properties/Trait/Header.hs
+++ b/webgear-server/test/Properties/Trait/Header.hs
@@ -12,7 +12,7 @@ import Test.Tasty (TestTree)
 import Test.Tasty.QuickCheck (testProperties)
 import WebGear.Core.Request (Request (..))
 import WebGear.Core.Trait (getTrait, wzero)
-import WebGear.Core.Trait.Header (Header (..), HeaderParseError (..), RequiredHeader)
+import WebGear.Core.Trait.Header (HeaderParseError (..), RequestHeader (..), RequiredRequestHeader)
 import WebGear.Server.Handler (runServerHandler)
 import WebGear.Server.Trait.Header ()
 
@@ -21,7 +21,7 @@ prop_headerParseError = property $ \hval ->
   let hval' = "test-" <> hval
       req = wzero $ Request $ defaultRequest{requestHeaders = [("foo", encodeUtf8 hval')]}
    in runIdentity $ do
-        res <- runServerHandler (getTrait (Header :: RequiredHeader "foo" Int)) [""] req
+        res <- runServerHandler (getTrait (RequestHeader :: RequiredRequestHeader "foo" Int)) [""] req
         pure $ case res of
           Right (Left e) ->
             e === Right (HeaderParseError $ "could not parse: `" <> hval' <> "' (input does not start with a digit)")
@@ -31,7 +31,7 @@ prop_headerParseSuccess :: Property
 prop_headerParseSuccess = property $ \(n :: Int) ->
   let req = wzero $ Request $ defaultRequest{requestHeaders = [("foo", fromString $ show n)]}
    in runIdentity $ do
-        res <- runServerHandler (getTrait (Header :: RequiredHeader "foo" Int)) [""] req
+        res <- runServerHandler (getTrait (RequestHeader :: RequiredRequestHeader "foo" Int)) [""] req
         pure $ case res of
           Right (Right n') -> n === n'
           e -> counterexample ("Unexpected result: " <> show e) (property False)

--- a/webgear-server/test/Properties/Trait/Method.hs
+++ b/webgear-server/test/Properties/Trait/Method.hs
@@ -18,7 +18,7 @@ import Test.QuickCheck (
 import Test.Tasty (TestTree)
 import Test.Tasty.QuickCheck (testProperties)
 import WebGear.Core.Request (Request (..))
-import WebGear.Core.Trait (getTrait, linkzero)
+import WebGear.Core.Trait (getTrait, wzero)
 import WebGear.Core.Trait.Method (Method (..), MethodMismatch (..))
 import WebGear.Server.Handler (runServerHandler)
 import WebGear.Server.Trait.Method ()
@@ -31,7 +31,7 @@ instance Arbitrary MethodWrapper where
 
 prop_methodMatch :: Property
 prop_methodMatch = property $ \(MethodWrapper v) ->
-  let req = linkzero $ Request $ defaultRequest{requestMethod = renderStdMethod v}
+  let req = wzero $ Request $ defaultRequest{requestMethod = renderStdMethod v}
    in runIdentity $ do
         res <- runServerHandler (getTrait (Method GET)) [""] req
         pure $ case res of

--- a/webgear-server/test/Properties/Trait/Path.hs
+++ b/webgear-server/test/Properties/Trait/Path.hs
@@ -9,16 +9,16 @@ import Test.QuickCheck (Property, allProperties, property, (=/=), (===))
 import Test.QuickCheck.Instances ()
 import Test.Tasty (TestTree)
 import Test.Tasty.QuickCheck (testProperties)
-import WebGear.Core.Trait.Path (Path (..), PathVar (..), PathVarError (..))
 import WebGear.Core.Request (Request (..))
-import WebGear.Core.Trait (getTrait, linkzero)
+import WebGear.Core.Trait (getTrait, wzero)
+import WebGear.Core.Trait.Path (Path (..), PathVar (..), PathVarError (..))
 import WebGear.Server.Handler (RoutePath (..), runServerHandler)
 import WebGear.Server.Trait.Path ()
 
 prop_pathMatch :: Property
 prop_pathMatch = property $ \h ->
   let rest = ["foo", "bar"]
-      req = linkzero $ Request $ defaultRequest{pathInfo = h : rest}
+      req = wzero $ Request $ defaultRequest{pathInfo = h : rest}
    in runIdentity $ do
         res <- runServerHandler (getTrait $ Path "a") (RoutePath $ h : rest) req
         pure $ case res of
@@ -30,7 +30,7 @@ prop_pathVarMatch :: Property
 prop_pathVarMatch = property $ \(n :: Int) ->
   let rest = ["foo", "bar"]
       p = fromString (show n) : rest
-      req = linkzero $ Request $ defaultRequest{pathInfo = p}
+      req = wzero $ Request $ defaultRequest{pathInfo = p}
    in runIdentity $ do
         res <- runServerHandler (getTrait (PathVar @"tag" @Int)) (RoutePath p) req
         pure $ case res of
@@ -40,7 +40,7 @@ prop_pathVarMatch = property $ \(n :: Int) ->
 prop_pathVarParseError :: Property
 prop_pathVarParseError = property $ \(p, ps) ->
   let p' = "test-" <> p
-      req = linkzero $ Request $ defaultRequest{pathInfo = p' : ps}
+      req = wzero $ Request $ defaultRequest{pathInfo = p' : ps}
    in runIdentity $ do
         res <- runServerHandler (getTrait (PathVar @"tag" @Int)) (RoutePath $ p' : ps) req
         pure $ case res of

--- a/webgear-server/test/Properties/Trait/QueryParam.hs
+++ b/webgear-server/test/Properties/Trait/QueryParam.hs
@@ -12,7 +12,7 @@ import Test.Tasty (TestTree)
 import Test.Tasty.QuickCheck (testProperties)
 import WebGear.Core.Modifiers (Existence (..), ParseStyle (..))
 import WebGear.Core.Request (Request (..))
-import WebGear.Core.Trait (getTrait, linkzero)
+import WebGear.Core.Trait (getTrait, wzero)
 import WebGear.Core.Trait.QueryParam (ParamParseError (..), QueryParam (..))
 import WebGear.Server.Handler (runServerHandler)
 import WebGear.Server.Trait.QueryParam ()
@@ -20,7 +20,7 @@ import WebGear.Server.Trait.QueryParam ()
 prop_paramParseError :: Property
 prop_paramParseError = property $ \hval ->
   let hval' = "test-" <> hval
-      req = linkzero $ Request $ defaultRequest{queryString = [("foo", Just $ encodeUtf8 hval')]}
+      req = wzero $ Request $ defaultRequest{queryString = [("foo", Just $ encodeUtf8 hval')]}
    in runIdentity $ do
         res <- runServerHandler (getTrait (QueryParam :: QueryParam Required Strict "foo" Int)) [""] req
         pure $ case res of
@@ -30,7 +30,7 @@ prop_paramParseError = property $ \hval ->
 
 prop_paramParseSuccess :: Property
 prop_paramParseSuccess = property $ \(n :: Int) ->
-  let req = linkzero $ Request $ defaultRequest{queryString = [("foo", Just $ fromString $ show n)]}
+  let req = wzero $ Request $ defaultRequest{queryString = [("foo", Just $ fromString $ show n)]}
    in runIdentity $ do
         res <- runServerHandler (getTrait (QueryParam :: QueryParam Required Strict "foo" Int)) [""] req
         pure $ case res of

--- a/webgear-server/test/Unit/Trait/Header.hs
+++ b/webgear-server/test/Unit/Trait/Header.hs
@@ -8,7 +8,7 @@ import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertFailure, testCase, (@?=))
 import WebGear.Core.Request (Request (..))
 import WebGear.Core.Trait (getTrait, wzero)
-import WebGear.Core.Trait.Header (Header (..), HeaderNotFound (..), RequiredHeader)
+import WebGear.Core.Trait.Header (HeaderNotFound (..), RequestHeader (..), RequiredRequestHeader)
 import WebGear.Server.Handler (runServerHandler)
 import WebGear.Server.Trait.Header ()
 
@@ -16,7 +16,7 @@ testMissingHeaderFails :: TestTree
 testMissingHeaderFails = testCase "Missing header fails Header trait" $ do
   let req = wzero $ Request $ defaultRequest{requestHeaders = []}
   runIdentity $ do
-    res <- runServerHandler (getTrait (Header :: RequiredHeader "foo" Int)) [""] req
+    res <- runServerHandler (getTrait (RequestHeader :: RequiredRequestHeader "foo" Int)) [""] req
     pure $ case res of
       Right (Left e) -> e @?= Left HeaderNotFound
       _ -> assertFailure "unexpected success"

--- a/webgear-server/test/Unit/Trait/Header.hs
+++ b/webgear-server/test/Unit/Trait/Header.hs
@@ -7,14 +7,14 @@ import Network.Wai (defaultRequest, requestHeaders)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertFailure, testCase, (@?=))
 import WebGear.Core.Request (Request (..))
-import WebGear.Core.Trait (getTrait, linkzero)
+import WebGear.Core.Trait (getTrait, wzero)
 import WebGear.Core.Trait.Header (Header (..), HeaderNotFound (..), RequiredHeader)
 import WebGear.Server.Handler (runServerHandler)
 import WebGear.Server.Trait.Header ()
 
 testMissingHeaderFails :: TestTree
 testMissingHeaderFails = testCase "Missing header fails Header trait" $ do
-  let req = linkzero $ Request $ defaultRequest{requestHeaders = []}
+  let req = wzero $ Request $ defaultRequest{requestHeaders = []}
   runIdentity $ do
     res <- runServerHandler (getTrait (Header :: RequiredHeader "foo" Int)) [""] req
     pure $ case res of

--- a/webgear-server/test/Unit/Trait/Path.hs
+++ b/webgear-server/test/Unit/Trait/Path.hs
@@ -6,15 +6,15 @@ import Data.Functor.Identity (runIdentity)
 import Network.Wai (defaultRequest, pathInfo)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertFailure, testCase, (@?=))
-import WebGear.Core.Trait.Path (PathVar (..), PathVarError (..))
 import WebGear.Core.Request (Request (..))
-import WebGear.Core.Trait (getTrait, linkzero)
+import WebGear.Core.Trait (getTrait, wzero)
+import WebGear.Core.Trait.Path (PathVar (..), PathVarError (..))
 import WebGear.Server.Handler (runServerHandler)
 import WebGear.Server.Trait.Path ()
 
 testMissingPathVar :: TestTree
 testMissingPathVar = testCase "PathVar match: missing variable" $ do
-  let req = linkzero $ Request $ defaultRequest{pathInfo = []}
+  let req = wzero $ Request $ defaultRequest{pathInfo = []}
   runIdentity $ do
     res <- runServerHandler (getTrait (PathVar @"tag" @Int)) [] req
     pure $ case res of


### PR DESCRIPTION
Fixes #18 

A bunch of changes to the API for usability enahancements:

- Use the version of HLS based on the GHC version used by `nix develop`
- Change the terminology from "linked" to "witnessed". Rename `Linked` type to `With`.
- Simplify `StdHandler` constraint to exclude the traits on `Request` and `Response`. One should explicitly use `Get` and `Set` constraints instead.
- Introduced `>->` and `<-<` operators to construct responses easily.
- Split some traits based on whether they make sense only for requests/responses.
- The `respond*A` traits now return an unwitnessed response because the typical use case is to immediately apply `unwitnessA` to its result.