### PR TITLE
Streaming APIs

### DIFF
--- a/webgear-core/src/WebGear/Core/Handler/Static.hs
+++ b/webgear-core/src/WebGear/Core/Handler/Static.hs
@@ -26,7 +26,7 @@ import Prelude hiding (readFile)
 serveDir ::
   ( MonadIO m
   , Handler h m
-  , Sets h [Status, RequiredResponseHeader "Content-Type" Mime.MimeType, Body LBS.ByteString] Response
+  , Sets h [Status, RequiredResponseHeader "Content-Type" Mime.MimeType, Body '[] LBS.ByteString] Response
   ) =>
   -- | The directory to serve
   FilePath ->
@@ -47,7 +47,7 @@ serveDir root index = proc _request -> consumeRoute go -< ()
 serveFile ::
   ( MonadIO m
   , Handler h m
-  , Sets h [Status, RequiredResponseHeader "Content-Type" Mime.MimeType, Body LBS.ByteString] Response
+  , Sets h [Status, RequiredResponseHeader "Content-Type" Mime.MimeType, Body '[] LBS.ByteString] Response
   ) =>
   h FilePath Response
 serveFile = proc file -> do

--- a/webgear-core/src/WebGear/Core/Handler/Static.hs
+++ b/webgear-core/src/WebGear/Core/Handler/Static.hs
@@ -7,15 +7,12 @@ module WebGear.Core.Handler.Static (
 ) where
 
 import Control.Arrow ((<<<))
-import Control.Exception.Safe (catchIO)
-import Control.Monad.IO.Class (MonadIO (..))
-import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Text as Text
 import qualified Network.Mime as Mime
 import System.FilePath (joinPath, takeFileName, (</>))
 import WebGear.Core.Handler (Handler (..), RoutePath (..), unwitnessA, (>->))
 import WebGear.Core.Request (Request (..))
-import WebGear.Core.Response (Response)
+import WebGear.Core.Response (Response, ResponseBody (..))
 import WebGear.Core.Trait (Sets, With)
 import WebGear.Core.Trait.Body (Body, setBodyWithoutContentType)
 import WebGear.Core.Trait.Header (RequiredResponseHeader, setHeader)
@@ -24,9 +21,8 @@ import Prelude hiding (readFile)
 
 -- | Serve files under the specified directory.
 serveDir ::
-  ( MonadIO m
-  , Handler h m
-  , Sets h [Status, RequiredResponseHeader "Content-Type" Mime.MimeType, Body '[] LBS.ByteString] Response
+  ( Handler h m
+  , Sets h [Status, RequiredResponseHeader "Content-Type" Mime.MimeType, Body '[] ResponseBody] Response
   ) =>
   -- | The directory to serve
   FilePath ->
@@ -45,20 +41,14 @@ serveDir root index = proc _request -> consumeRoute go -< ()
 
 -- | Serve a file specified by the input filepath.
 serveFile ::
-  ( MonadIO m
-  , Handler h m
-  , Sets h [Status, RequiredResponseHeader "Content-Type" Mime.MimeType, Body '[] LBS.ByteString] Response
+  ( Handler h m
+  , Sets h [Status, RequiredResponseHeader "Content-Type" Mime.MimeType, Body '[] ResponseBody] Response
   ) =>
   h FilePath Response
 serveFile = proc file -> do
-  maybeContents <- readFile -< file
-  case maybeContents of
-    Nothing -> unwitnessA <<< notFound404 -< ()
-    Just contents -> do
-      let contentType = Mime.defaultMimeLookup $ Text.pack $ takeFileName file
-      (ok200 -< ())
-        >-> (\resp -> setBodyWithoutContentType -< (resp, contents))
-        >-> (\resp -> setHeader @"Content-Type" -< (resp, contentType))
-        >-> (\resp -> unwitnessA -< resp)
-  where
-    readFile = arrM $ \f -> liftIO $ (Just <$> LBS.readFile f) `catchIO` const (pure Nothing)
+  let contents = ResponseBodyFile file Nothing
+      contentType = Mime.defaultMimeLookup $ Text.pack $ takeFileName file
+  (ok200 -< ())
+    >-> (\resp -> setBodyWithoutContentType -< (resp, contents))
+    >-> (\resp -> setHeader @"Content-Type" -< (resp, contentType))
+    >-> (\resp -> unwitnessA -< resp)

--- a/webgear-core/src/WebGear/Core/Trait/Auth/Common.hs
+++ b/webgear-core/src/WebGear/Core/Trait/Auth/Common.hs
@@ -25,7 +25,7 @@ import WebGear.Core.Modifiers (Existence (..), ParseStyle (..))
 import WebGear.Core.Request (Request)
 import WebGear.Core.Response (Response)
 import WebGear.Core.Trait (Get (..), Sets, With)
-import WebGear.Core.Trait.Body (Body, setBody)
+import WebGear.Core.Trait.Body (Body, PlainText, setBody)
 import WebGear.Core.Trait.Header (RequestHeader (..), RequiredResponseHeader, setHeader)
 import WebGear.Core.Trait.Status (Status, unauthorized401)
 import Prelude hiding (break, drop)
@@ -84,7 +84,7 @@ respondUnauthorized ::
       [ Status
       , RequiredResponseHeader "Content-Type" Text
       , RequiredResponseHeader "WWW-Authenticate" Text
-      , Body Text
+      , Body '[PlainText] Text
       ]
       Response
   ) =>
@@ -96,7 +96,7 @@ respondUnauthorized ::
 respondUnauthorized scheme (Realm realm) = proc _ -> do
   let headerVal = decodeUtf8 $ original scheme <> " realm=\"" <> realm <> "\""
   (unauthorized401 -< ())
-    >-> (\resp -> setBody "text/plain" -< (resp, "Unauthorized" :: Text))
+    >-> (\resp -> setBody @PlainText -< (resp, "Unauthorized" :: Text))
     >-> (\resp -> setHeader @"WWW-Authenticate" -< (resp, headerVal))
     >-> (\resp -> unwitnessA -< resp)
 {-# INLINE respondUnauthorized #-}

--- a/webgear-core/src/WebGear/Core/Trait/Status.hs
+++ b/webgear-core/src/WebGear/Core/Trait/Status.hs
@@ -53,7 +53,7 @@ module WebGear.Core.Trait.Status (
 ) where
 
 import qualified Network.HTTP.Types as HTTP
-import WebGear.Core.Response (Response (..))
+import WebGear.Core.Response (Response (..), ResponseBody (ResponseBodyBuilder))
 import WebGear.Core.Trait (Set, Trait (..), With, plant, wzero)
 
 -- | HTTP response status
@@ -65,7 +65,7 @@ instance Trait Status Response where
 -- | Generate a response with the specified status
 mkResponse :: (Set h Status Response) => HTTP.Status -> h () (Response `With` '[Status])
 mkResponse status = proc () -> do
-  let response = wzero $ Response status [] Nothing
+  let response = wzero $ Response status [] (ResponseBodyBuilder mempty)
   plant (Status status) -< (response, status)
 {-# INLINE mkResponse #-}
 

--- a/webgear-core/src/WebGear/Core/Traits.hs
+++ b/webgear-core/src/WebGear/Core/Traits.hs
@@ -12,6 +12,8 @@ module WebGear.Core.Traits (
   StdHandler,
 ) where
 
+import qualified Data.Text as Text
+import qualified Data.Text.Lazy as LText
 import WebGear.Core.Handler (Handler)
 import WebGear.Core.Request (Request)
 import WebGear.Core.Response (Response)
@@ -36,5 +38,12 @@ import WebGear.Core.Trait.Status
 type StdHandler h m =
   ( Handler h m
   , Gets h [Method, Path, PathEnd] Request
-  , Sets h '[Status] Response
+  , Sets
+      h
+      '[ Status
+       , Body '[PlainText] String
+       , Body '[PlainText] Text.Text
+       , Body '[PlainText] LText.Text
+       ]
+      Response
   )

--- a/webgear-core/webgear-core.cabal
+++ b/webgear-core/webgear-core.cabal
@@ -54,6 +54,7 @@ common webgear-common
                       TypeFamilies
                       TypeOperators
   build-depends:      base >=4.13.0.0 && <4.19
+                    , binary >= 0.8.0.0 && <0.9
                     , bytestring >=0.10.10.1 && <0.13
                     , case-insensitive ==1.2.*
                     , filepath ==1.4.*
@@ -65,7 +66,6 @@ common webgear-common
                     , tagged ==0.8.*
                     , template-haskell >=2.15.0.0 && <2.21
                     , text >=1.2.0.0 && <2.2
-                    , unordered-containers ==0.2.*
                     , wai ==3.2.*
   ghc-options:        -Wall
                       -Wno-unticked-promoted-constructors

--- a/webgear-core/webgear-core.cabal
+++ b/webgear-core/webgear-core.cabal
@@ -62,7 +62,6 @@ common webgear-common
                     , http-media ==0.8.*
                     , http-types ==0.12.*
                     , network ==3.1.*
-                    , safe-exceptions ==0.1.*
                     , tagged ==0.8.*
                     , template-haskell >=2.15.0.0 && <2.21
                     , text >=1.2.0.0 && <2.2

--- a/webgear-openapi/src/WebGear/OpenApi/Trait/Body.hs
+++ b/webgear-openapi/src/WebGear/OpenApi/Trait/Body.hs
@@ -4,57 +4,41 @@
 module WebGear.OpenApi.Trait.Body where
 
 import Control.Lens ((&), (.~), (?~))
-import Data.Maybe (fromMaybe)
 import Data.OpenApi hiding (Response)
 import Data.OpenApi.Declare (runDeclare)
 import Data.Proxy (Proxy (..))
 import Data.Text (Text)
+import GHC.Exts (fromList)
 import WebGear.Core.Request (Request)
 import WebGear.Core.Response (Response (..))
 import WebGear.Core.Trait (Get (..), Set (..), With)
-import WebGear.Core.Trait.Body (Body (..), JSONBody (..))
+import WebGear.Core.Trait.Body (Body (..), MIMETypes (..))
 import WebGear.OpenApi.Handler (
   DocNode (DocRequestBody, DocResponseBody),
   OpenApiHandler (..),
   singletonNode,
  )
 
-instance (ToSchema val) => Get (OpenApiHandler m) (Body val) Request where
+instance (ToSchema val, MIMETypes mts) => Get (OpenApiHandler m) (Body mts val) Request where
   {-# INLINE getTrait #-}
-  getTrait :: Body val -> OpenApiHandler m (Request `With` ts) (Either Text val)
-  getTrait (Body maybeMediaType) =
-    let mediaType = fromMaybe "*/*" maybeMediaType
+  getTrait :: Body mts val -> OpenApiHandler m (Request `With` ts) (Either Text val)
+  getTrait Body =
+    let mediaTypes = mimeTypes $ Proxy @mts
         (defs, ref) = runDeclare (declareSchemaRef $ Proxy @val) mempty
         body =
           (mempty @RequestBody)
-            & content .~ [(mediaType, mempty @MediaTypeObject & schema ?~ ref)]
+            & content .~ fromList (map (,mempty @MediaTypeObject & schema ?~ ref) mediaTypes)
      in OpenApiHandler $ singletonNode (DocRequestBody defs body)
 
-instance (ToSchema val) => Set (OpenApiHandler m) (Body val) Response where
+instance (ToSchema val, MIMETypes mts) => Set (OpenApiHandler m) (Body mts val) Response where
   {-# INLINE setTrait #-}
   setTrait ::
-    Body val ->
-    (Response `With` ts -> Response -> val -> Response `With` (Body val : ts)) ->
-    OpenApiHandler m (Response `With` ts, val) (Response `With` (Body val : ts))
-  setTrait (Body maybeMediaType) _ =
-    let mediaType = fromMaybe "*/*" maybeMediaType
+    Body mts val ->
+    (Response `With` ts -> Response -> val -> Response `With` (Body mts val : ts)) ->
+    OpenApiHandler m (Response `With` ts, val) (Response `With` (Body mts val : ts))
+  setTrait Body _ =
+    let mediaTypes = mimeTypes $ Proxy @mts
         (defs, ref) = runDeclare (declareSchemaRef $ Proxy @val) mempty
         body = mempty @MediaTypeObject & schema ?~ ref
-     in OpenApiHandler $ singletonNode (DocResponseBody defs mediaType body)
-
-instance (ToSchema val) => Get (OpenApiHandler m) (JSONBody val) Request where
-  {-# INLINE getTrait #-}
-  getTrait :: JSONBody val -> OpenApiHandler m (Request `With` ts) (Either Text val)
-  getTrait (JSONBody maybeMediaType) = getTrait (Body @val maybeMediaType)
-
-instance (ToSchema val) => Set (OpenApiHandler m) (JSONBody val) Response where
-  {-# INLINE setTrait #-}
-  setTrait ::
-    JSONBody val ->
-    (Response `With` ts -> Response -> t -> Response `With` (JSONBody val : ts)) ->
-    OpenApiHandler m (Response `With` ts, t) (Response `With` (JSONBody val : ts))
-  setTrait (JSONBody maybeMediaType) _ =
-    let mediaType = fromMaybe "*/*" maybeMediaType
-        (defs, ref) = runDeclare (declareSchemaRef $ Proxy @val) mempty
-        body = mempty @MediaTypeObject & schema ?~ ref
-     in OpenApiHandler $ singletonNode (DocResponseBody defs mediaType body)
+        mts = fromList $ map (,body) mediaTypes
+     in OpenApiHandler $ singletonNode (DocResponseBody defs mts)

--- a/webgear-openapi/webgear-openapi.cabal
+++ b/webgear-openapi/webgear-openapi.cabal
@@ -63,6 +63,7 @@ library
                       ScopedTypeVariables
                       StandaloneDeriving
                       TemplateHaskellQuotes
+                      TupleSections
                       TypeApplications
                       TypeFamilies
                       TypeOperators

--- a/webgear-server/src/WebGear/Server/Trait/Body.hs
+++ b/webgear-server/src/WebGear/Server/Trait/Body.hs
@@ -114,3 +114,31 @@ instance (Monad m, Aeson.ToJSON val) => Set (ServerHandler m) (Body '[JSON' mt] 
             { responseBody = ResponseBodyBuilder $ Aeson.fromEncoding $ Aeson.toEncoding val
             }
     returnA -< f wResponse response' val
+
+instance (Monad m) => Set (ServerHandler m) (Body '[] ResponseBody) Response where
+  {-# INLINE setTrait #-}
+  setTrait ::
+    Body '[] ResponseBody ->
+    (Response `With` ts -> Response -> ResponseBody -> Response `With` (Body '[] ResponseBody : ts)) ->
+    ServerHandler m (Response `With` ts, ResponseBody) (Response `With` (Body '[] ResponseBody : ts))
+  setTrait Body f = proc (wResponse, body) -> do
+    let response = unwitness wResponse
+        response' =
+          response
+            { responseBody = body
+            }
+    returnA -< f wResponse response' body
+
+instance (Monad m) => Set (ServerHandler m) (Body '[mt] ResponseBody) Response where
+  {-# INLINE setTrait #-}
+  setTrait ::
+    Body '[mt] ResponseBody ->
+    (Response `With` ts -> Response -> ResponseBody -> Response `With` (Body '[mt] ResponseBody : ts)) ->
+    ServerHandler m (Response `With` ts, ResponseBody) (Response `With` (Body '[mt] ResponseBody : ts))
+  setTrait Body f = proc (wResponse, body) -> do
+    let response = unwitness wResponse
+        response' =
+          response
+            { responseBody = body
+            }
+    returnA -< f wResponse response' body

--- a/webgear-server/src/WebGear/Server/Trait/Body.hs
+++ b/webgear-server/src/WebGear/Server/Trait/Body.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | Server implementation of the `Body` trait.
@@ -7,76 +8,109 @@ import Control.Arrow (returnA)
 import Control.Monad.IO.Class (MonadIO (..))
 import qualified Data.Aeson as Aeson
 import Data.ByteString.Conversion (FromByteString, ToByteString (..), parser, runParser')
-import Data.ByteString.Lazy (fromChunks)
+import qualified Data.ByteString.Lazy as LBS
 import Data.Text (Text, pack)
-import Network.HTTP.Media.RenderHeader (RenderHeader (renderHeader))
-import Network.HTTP.Types (hContentType)
+import Data.Text.Conversions (FromText (..), ToText (..))
+import qualified Data.Text.Encoding as Text
+import qualified Data.Text.Lazy as LText
+import qualified Data.Text.Lazy.Encoding as LText
+import Network.Wai (lazyRequestBody)
 import WebGear.Core.Handler (Handler (..))
-import WebGear.Core.Request (Request, getRequestBodyChunk)
+import WebGear.Core.Request (Request (..))
 import WebGear.Core.Response (Response (..), ResponseBody (ResponseBodyBuilder))
 import WebGear.Core.Trait (Get (..), Set (..), With, unwitness)
-import WebGear.Core.Trait.Body (Body (..), JSONBody (..))
+import WebGear.Core.Trait.Body (
+  Body (..),
+  JSON',
+  OctetStream,
+  PlainText,
+ )
 import WebGear.Server.Handler (ServerHandler)
 
-instance (MonadIO m, FromByteString val) => Get (ServerHandler m) (Body val) Request where
+instance
+  {-# OVERLAPPABLE #-}
+  ( Monad m
+  , Get (ServerHandler m) (Body '[mtyp] val) Request
+  , Get (ServerHandler m) (Body mtyps val) Request
+  ) =>
+  Get (ServerHandler m) (Body (mtyp : mtyps) val) Request
+  where
   {-# INLINE getTrait #-}
-  getTrait :: Body val -> ServerHandler m (Request `With` ts) (Either Text val)
-  getTrait (Body _) = arrM $ \request -> do
-    chunks <- takeWhileM (/= mempty) $ repeat $ liftIO $ getRequestBodyChunk $ unwitness request
-    pure $ case runParser' parser (fromChunks chunks) of
+  getTrait :: Body (mtyp : mtyps) val -> ServerHandler m (Request `With` ts) (Either Text val)
+  getTrait Body = proc request -> do
+    result <- getTrait (Body @'[mtyp] @val) -< request
+    case result of
+      Left _ -> getTrait (Body @mtyps @val) -< request
+      Right t -> returnA -< Right t
+
+bodyToByteString :: (MonadIO m) => Request `With` ts -> m LBS.ByteString
+bodyToByteString = liftIO . lazyRequestBody . toWaiRequest . unwitness
+
+instance (MonadIO m, FromByteString val) => Get (ServerHandler m) (Body '[OctetStream] val) Request where
+  {-# INLINE getTrait #-}
+  getTrait :: Body '[OctetStream] val -> ServerHandler m (Request `With` ts) (Either Text val)
+  getTrait Body = arrM $ \request -> do
+    body <- bodyToByteString request
+    pure $ case runParser' parser body of
       Left e -> Left $ pack e
       Right t -> Right t
 
-instance (Monad m, ToByteString val) => Set (ServerHandler m) (Body val) Response where
+instance (MonadIO m, FromText val) => Get (ServerHandler m) (Body '[PlainText] val) Request where
+  {-# INLINE getTrait #-}
+  getTrait :: Body '[PlainText] val -> ServerHandler m (Request `With` ts) (Either Text val)
+  getTrait Body = arrM $ \request -> do
+    body <- bodyToByteString request
+    pure $ case LText.decodeUtf8' body of
+      Left e -> Left $ pack $ show e
+      Right t -> Right $ fromText $ LText.toStrict t
+
+instance (MonadIO m, Aeson.FromJSON val) => Get (ServerHandler m) (Body '[JSON' mt] val) Request where
+  {-# INLINE getTrait #-}
+  getTrait :: Body '[JSON' mt] val -> ServerHandler m (Request `With` ts) (Either Text val)
+  getTrait Body = arrM $ \request -> do
+    body <- bodyToByteString request
+    pure $ case Aeson.eitherDecode' body of
+      Left e -> Left $ pack e
+      Right t -> Right t
+
+instance (Monad m, ToByteString val) => Set (ServerHandler m) (Body '[OctetStream] val) Response where
   {-# INLINE setTrait #-}
   setTrait ::
-    Body val ->
-    (Response `With` ts -> Response -> val -> Response `With` (Body val : ts)) ->
-    ServerHandler m (Response `With` ts, val) (Response `With` (Body val : ts))
-  setTrait (Body mediaType) f = proc (wResponse, val) -> do
+    Body '[OctetStream] val ->
+    (Response `With` ts -> Response -> val -> Response `With` (Body '[OctetStream] val : ts)) ->
+    ServerHandler m (Response `With` ts, val) (Response `With` (Body '[OctetStream] val : ts))
+  setTrait Body f = proc (wResponse, val) -> do
     let response = unwitness wResponse
         response' =
           response
             { responseBody = ResponseBodyBuilder (builder val)
-            , responseHeaders =
-                responseHeaders response
-                  <> case mediaType of
-                    Just mt -> [(hContentType, renderHeader mt)]
-                    Nothing -> []
             }
     returnA -< f wResponse response' val
 
-instance (MonadIO m, Aeson.FromJSON val) => Get (ServerHandler m) (JSONBody val) Request where
-  {-# INLINE getTrait #-}
-  getTrait :: JSONBody val -> ServerHandler m (Request `With` ts) (Either Text val)
-  getTrait (JSONBody _) = arrM $ \request -> do
-    chunks <- takeWhileM (/= mempty) $ repeat $ liftIO $ getRequestBodyChunk $ unwitness request
-    pure $ case Aeson.eitherDecode' (fromChunks chunks) of
-      Left e -> Left $ pack e
-      Right t -> Right t
-
-instance (Monad m, Aeson.ToJSON val) => Set (ServerHandler m) (JSONBody val) Response where
+instance (Monad m, ToText val) => Set (ServerHandler m) (Body '[PlainText] val) Response where
   {-# INLINE setTrait #-}
   setTrait ::
-    JSONBody val ->
-    (Response `With` ts -> Response -> val -> Response `With` (JSONBody val : ts)) ->
-    ServerHandler m (Response `With` ts, val) (Response `With` (JSONBody val : ts))
-  setTrait (JSONBody mediaType) f = proc (wResponse, val) -> do
+    Body '[PlainText] val ->
+    (Response `With` ts -> Response -> val -> Response `With` (Body '[PlainText] val : ts)) ->
+    ServerHandler m (Response `With` ts, val) (Response `With` (Body '[PlainText] val : ts))
+  setTrait Body f = proc (wResponse, val) -> do
     let response = unwitness wResponse
-        ctype = maybe "application/json" renderHeader mediaType
+        response' =
+          response
+            { responseBody = ResponseBodyBuilder (Text.encodeUtf8Builder $ toText val)
+            }
+    returnA -< f wResponse response' val
+
+instance (Monad m, Aeson.ToJSON val) => Set (ServerHandler m) (Body '[JSON' mt] val) Response where
+  {-# INLINE setTrait #-}
+  setTrait ::
+    Body '[JSON' mt] val ->
+    (Response `With` ts -> Response -> val -> Response `With` (Body '[JSON' mt] val : ts)) ->
+    ServerHandler m (Response `With` ts, val) (Response `With` (Body '[JSON' mt] val : ts))
+  setTrait Body f = proc (wResponse, val) -> do
+    let response = unwitness wResponse
         response' =
           response
             { responseBody = ResponseBodyBuilder $ Aeson.fromEncoding $ Aeson.toEncoding val
-            , responseHeaders =
-                responseHeaders response
-                  <> [(hContentType, ctype)]
             }
     returnA -< f wResponse response' val
-
-takeWhileM :: (Monad m) => (a -> Bool) -> [m a] -> m [a]
-takeWhileM _ [] = pure []
-takeWhileM p (mx : mxs) = do
-  x <- mx
-  if p x
-    then (x :) <$> takeWhileM p mxs
-    else pure []

--- a/webgear-server/src/WebGear/Server/Trait/Body.hs
+++ b/webgear-server/src/WebGear/Server/Trait/Body.hs
@@ -6,14 +6,14 @@ module WebGear.Server.Trait.Body () where
 import Control.Arrow (returnA)
 import Control.Monad.IO.Class (MonadIO (..))
 import qualified Data.Aeson as Aeson
-import Data.ByteString.Conversion (FromByteString, ToByteString, parser, runParser', toByteString)
+import Data.ByteString.Conversion (FromByteString, ToByteString (..), parser, runParser')
 import Data.ByteString.Lazy (fromChunks)
 import Data.Text (Text, pack)
 import Network.HTTP.Media.RenderHeader (RenderHeader (renderHeader))
 import Network.HTTP.Types (hContentType)
 import WebGear.Core.Handler (Handler (..))
 import WebGear.Core.Request (Request, getRequestBodyChunk)
-import WebGear.Core.Response (Response (..))
+import WebGear.Core.Response (Response (..), ResponseBody (ResponseBodyBuilder))
 import WebGear.Core.Trait (Get (..), Set (..), With, unwitness)
 import WebGear.Core.Trait.Body (Body (..), JSONBody (..))
 import WebGear.Server.Handler (ServerHandler)
@@ -37,7 +37,7 @@ instance (Monad m, ToByteString val) => Set (ServerHandler m) (Body val) Respons
     let response = unwitness wResponse
         response' =
           response
-            { responseBody = Just (toByteString val)
+            { responseBody = ResponseBodyBuilder (builder val)
             , responseHeaders =
                 responseHeaders response
                   <> case mediaType of
@@ -66,7 +66,7 @@ instance (Monad m, Aeson.ToJSON val) => Set (ServerHandler m) (JSONBody val) Res
         ctype = maybe "application/json" renderHeader mediaType
         response' =
           response
-            { responseBody = Just (Aeson.encode val)
+            { responseBody = ResponseBodyBuilder $ Aeson.fromEncoding $ Aeson.toEncoding val
             , responseHeaders =
                 responseHeaders response
                   <> [(hContentType, ctype)]

--- a/webgear-server/test/Properties/Trait/Body.hs
+++ b/webgear-server/test/Properties/Trait/Body.hs
@@ -15,12 +15,12 @@ import Test.Tasty (TestTree)
 import Test.Tasty.QuickCheck (testProperties)
 import WebGear.Core.Request (Request (..))
 import WebGear.Core.Trait (With, getTrait, wzero)
-import WebGear.Core.Trait.Body (JSONBody (..))
+import WebGear.Core.Trait.Body (Body (..), JSON)
 import WebGear.Server.Handler (runServerHandler)
 import WebGear.Server.Trait.Body ()
 
-jsonBody :: JSONBody t
-jsonBody = JSONBody (Just "application/json")
+jsonBody :: Body '[JSON] t
+jsonBody = Body
 
 bodyToRequest :: (MonadIO m, Show a) => a -> m (Request `With` '[])
 bodyToRequest x = do
@@ -31,7 +31,7 @@ bodyToRequest x = do
 prop_emptyRequestBodyFails :: Property
 prop_emptyRequestBodyFails = monadicIO $ do
   req <- bodyToRequest ("" :: String)
-  runServerHandler (getTrait (jsonBody :: JSONBody Int)) [""] req >>= \case
+  runServerHandler (getTrait (jsonBody @Int)) [""] req >>= \case
     Right (Left _) -> assert True
     e -> monitor (counterexample $ "Unexpected " <> show e) >> assert False
 
@@ -45,7 +45,7 @@ prop_validBodyParses = property $ \n -> monadicIO $ do
 prop_invalidBodyTypeFails :: Property
 prop_invalidBodyTypeFails = property $ \n -> monadicIO $ do
   req <- bodyToRequest (n :: Integer)
-  runServerHandler (getTrait (jsonBody :: JSONBody String)) [""] req >>= \case
+  runServerHandler (getTrait (jsonBody @String)) [""] req >>= \case
     Right (Left _) -> assert True
     _ -> assert False
 

--- a/webgear-server/webgear-server.cabal
+++ b/webgear-server/webgear-server.cabal
@@ -100,7 +100,6 @@ library
                     , jose >=0.8.3.1 && <0.11
                     , monad-time >=0.3.0.0 && <0.5
                     , mtl >=2.2 && <2.4
-                    , unordered-containers ==0.2.*
 
 test-suite webgear-server-test
   import:             webgear-common

--- a/webgear-server/webgear-server.cabal
+++ b/webgear-server/webgear-server.cabal
@@ -96,10 +96,10 @@ library
                     , arrows ==0.4.*
                     , bytestring-conversion ==0.3.*
                     , http-api-data >=0.4.2 && <0.7
-                    , http-media ==0.8.*
                     , jose >=0.8.3.1 && <0.11
                     , monad-time >=0.3.0.0 && <0.5
                     , mtl >=2.2 && <2.4
+                    , text-conversions ==0.3.*
 
 test-suite webgear-server-test
   import:             webgear-common


### PR DESCRIPTION
Fixes #21 

Implement streaming support.

- Added `ResponeBody` type matching the corresponding type in WAI. `ResponseBodyStream` can be used to stream responses.
- Remove the special `JSONBody` type and associated middlewares.
- Introduce a type level list of MIME types in the `Body` type.
- Introduce common MIME types - `OctetStream`, `PlainText`, and `JSON`.