### PR TITLE
Support for embedding WAI applications in handlers

### DIFF
--- a/webgear-core/CHANGELOG.md
+++ b/webgear-core/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Support for embedding WAI applications in handlers (#36)
+
 ## [1.1.1] - 2024-01-01
 
 ### Changed

--- a/webgear-core/src/WebGear/Core/Handler/Static.hs
+++ b/webgear-core/src/WebGear/Core/Handler/Static.hs
@@ -2,65 +2,22 @@
  Handlers for serving static resources
 -}
 module WebGear.Core.Handler.Static (
-  serveDir,
-  serveFile,
+  serveStatic,
 ) where
 
-import Control.Arrow ((<<<))
-import qualified Data.Text as Text
-import qualified Network.Mime as Mime
-import System.FilePath (joinPath, takeFileName, (</>))
-import WebGear.Core.Handler (Handler (..), RoutePath (..), unwitnessA, (>->))
-import WebGear.Core.Request (Request (..))
-import WebGear.Core.Response (Response, ResponseBody (..))
-import WebGear.Core.Trait (Sets, With)
-import WebGear.Core.Trait.Body (UnknownContentBody, setBodyWithoutContentType)
-import WebGear.Core.Trait.Header (RequiredResponseHeader, setHeader)
-import WebGear.Core.Trait.Status (Status, notFound404, ok200)
+import Control.Arrow (returnA)
+import Network.Wai (Request (..))
+import qualified Network.Wai.Application.Static as Wai.Static
+import WebGear.Core.Handler (Handler (..), RequestHandler, RoutePath (..))
+import WebGear.Core.Request (toWaiRequest)
+import WebGear.Core.Response (Response (ResponseCont))
+import WebGear.Core.Trait (unwitness)
 import Prelude hiding (readFile)
 
--- | Serve files under the specified directory.
-serveDir ::
-  ( Handler h m
-  , Sets
-      h
-      [ Status
-      , RequiredResponseHeader "Content-Type" Mime.MimeType
-      , UnknownContentBody
-      ]
-      Response
-  ) =>
-  -- | The directory to serve
-  FilePath ->
-  -- | Optional index filename for the root directory. A 404 Not Found
-  -- response will be returned for requests to the root path if this
-  -- is set to @Nothing@.
-  Maybe FilePath ->
-  h (Request `With` ts) Response
-serveDir root index = proc _request -> consumeRoute go -< ()
-  where
-    go = proc path -> do
-      case (path, index) of
-        (RoutePath [], Nothing) -> unwitnessA <<< notFound404 -< ()
-        (RoutePath [], Just f) -> serveFile -< root </> f
-        (RoutePath ps, _) -> serveFile -< root </> joinPath (Text.unpack <$> ps)
-
--- | Serve a file specified by the input filepath.
-serveFile ::
-  ( Handler h m
-  , Sets
-      h
-      [ Status
-      , RequiredResponseHeader "Content-Type" Mime.MimeType
-      , UnknownContentBody
-      ]
-      Response
-  ) =>
-  h FilePath Response
-serveFile = proc file -> do
-  let contents = ResponseBodyFile file Nothing
-      contentType = Mime.defaultMimeLookup $ Text.pack $ takeFileName file
-  (ok200 -< ())
-    >-> (\resp -> setBodyWithoutContentType -< (resp, contents))
-    >-> (\resp -> setHeader @"Content-Type" -< (resp, contentType))
-    >-> (\resp -> unwitnessA -< resp)
+-- | Serve static assets
+serveStatic :: (Handler h m) => Wai.Static.StaticSettings -> RequestHandler h ts
+serveStatic settings =
+  proc request -> do
+    RoutePath pathInfo <- consumeRoute returnA -< ()
+    let waiRequest = toWaiRequest $ unwitness request
+    returnA -< ResponseCont $ Wai.Static.staticApp settings waiRequest{pathInfo}

--- a/webgear-core/webgear-core.cabal
+++ b/webgear-core/webgear-core.cabal
@@ -58,7 +58,6 @@ common webgear-common
                     , bytestring >=0.10.10.1 && <0.13
                     , case-insensitive ==1.2.*
                     , cookie >=0.4.5 && <0.5
-                    , filepath >=1.4.2.1 && <1.6
                     , http-api-data >=0.4.2 && <0.7
                     , http-media ==0.8.*
                     , http-types ==0.12.*
@@ -67,6 +66,7 @@ common webgear-common
                     , template-haskell >=2.15.0.0 && <2.21
                     , text >=1.2.0.0 && <2.2
                     , wai ==3.2.*
+                    , wai-app-static ==3.1.*
                     , wai-extra ==3.1.*
   ghc-options:        -Wall
                       -Wno-unticked-promoted-constructors
@@ -108,4 +108,3 @@ library
   hs-source-dirs:     src
   build-depends:      arrows ==0.4.*
                     , jose >=0.8.3.1 && <0.12
-                    , mime-types ==0.1.*

--- a/webgear-example-realworld/src/API/UI.hs
+++ b/webgear-example-realworld/src/API/UI.hs
@@ -1,30 +1,12 @@
 module API.UI where
 
 import API.Common (App)
-import Network.Mime (MimeType)
+import Network.Wai.Application.Static (StaticSettings (..), defaultWebAppSettings)
 import Relude
+import WaiAppStatic.Types (unsafeToPiece)
 import WebGear.Server
 
-assets ::
-  ( StdHandler h App
-  , Sets
-      h
-      [ RequiredResponseHeader "Content-Type" MimeType
-      , UnknownContentBody
-      ]
-      Response
-  ) =>
-  RequestHandler h ts
-assets = serveDir "ui/assets" Nothing
-
-index ::
-  ( StdHandler h App
-  , Sets
-      h
-      [ RequiredResponseHeader "Content-Type" MimeType
-      , UnknownContentBody
-      ]
-      Response
-  ) =>
-  RequestHandler h ts
-index = proc _ -> serveFile -< "ui/index.html"
+assets :: (Handler h App) => RequestHandler h ts
+assets =
+  let settings = (defaultWebAppSettings "ui"){ssIndices = unsafeToPiece <$> ["index.html", "index.htm"]}
+   in serveStatic settings

--- a/webgear-example-realworld/src/Main.hs
+++ b/webgear-example-realworld/src/Main.hs
@@ -54,13 +54,10 @@ application pool jwk = toApplication $ transform appToIO allRoutes
   where
     allRoutes =
       appRoutes jwk
-        <+> uiRoutes
         <+> [match| /openapi |] (swaggerUI $ toOpenApi @App $ appRoutes jwk)
+        <+> uiRoutes
 
-    uiRoutes =
-      [match|       GET  /ui/assets |] UI.assets
-        <+> [match| GET  /ui        |] UI.index
-        <+> [route| GET  /          |] UI.index
+    uiRoutes = method GET UI.assets
 
     appToIO :: App a -> IO a
     appToIO = flip runReaderT (AppEnv pool) . unApp

--- a/webgear-example-realworld/ui/index.html
+++ b/webgear-example-realworld/ui/index.html
@@ -8,23 +8,21 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     
-<meta name="ember-realworld/config/environment" content="%7B%22modulePrefix%22%3A%22ember-realworld%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2Fui%2F%22%2C%22locationType%22%3A%22history%22%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%22EMBER_NATIVE_DECORATOR_SUPPORT%22%3Atrue%2C%22EMBER_METAL_TRACKED_PROPERTIES%22%3Atrue%2C%22EMBER_GLIMMER_ANGLE_BRACKET_NESTED_LOOKUP%22%3Atrue%2C%22EMBER_GLIMMER_ANGLE_BRACKET_BUILT_INS%22%3Atrue%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%22apiHost%22%3A%22http%3A%2F%2Flocalhost%3A3000%2Fapi%22%2C%22name%22%3A%22ember-realworld%22%2C%22version%22%3A%220.1.0%2Bd803258c%22%7D%2C%22ember-cli-mirage%22%3A%7B%22enabled%22%3Afalse%2C%22usingProxy%22%3Afalse%2C%22useDefaultPassthroughs%22%3Atrue%7D%2C%22exportApplicationGlobal%22%3Afalse%7D" />
+<meta name="ember-realworld/config/environment" content="%7B%22modulePrefix%22%3A%22ember-realworld%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22history%22%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%22EMBER_NATIVE_DECORATOR_SUPPORT%22%3Atrue%2C%22EMBER_METAL_TRACKED_PROPERTIES%22%3Atrue%2C%22EMBER_GLIMMER_ANGLE_BRACKET_NESTED_LOOKUP%22%3Atrue%2C%22EMBER_GLIMMER_ANGLE_BRACKET_BUILT_INS%22%3Atrue%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%22apiHost%22%3A%22http%3A%2F%2Flocalhost%3A3000%2Fapi%22%2C%22name%22%3A%22ember-realworld%22%2C%22version%22%3A%220.1.0%2Bd803258c%22%7D%2C%22ember-cli-mirage%22%3A%7B%22enabled%22%3Afalse%2C%22usingProxy%22%3Afalse%2C%22useDefaultPassthroughs%22%3Atrue%7D%2C%22exportApplicationGlobal%22%3Afalse%7D" />
 
     <link href="//code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css" rel="stylesheet" type="text/css">
     <link href="//fonts.googleapis.com/css?family=Titillium+Web:700|Source+Serif+Pro:400,700|Merriweather+Sans:400,700|Source+Sans+Pro:400,300,600,700,300italic,400italic,600italic,700italic" rel="stylesheet" type="text/css">
     <link rel="stylesheet" href="//demo.productionready.io/main.css">
-    <link rel="stylesheet" href="/ui/assets/vendor-d41d8cd98f00b204e9800998ecf8427e.css">
-    <link rel="stylesheet" href="/ui/assets/ember-realworld-d41d8cd98f00b204e9800998ecf8427e.css">
-    <link rel="icon" type="image/png" href="/ui/assets/ember.ico">
+    <link rel="stylesheet" href="/assets/vendor-d41d8cd98f00b204e9800998ecf8427e.css">
+    <link rel="stylesheet" href="/assets/ember-realworld-d41d8cd98f00b204e9800998ecf8427e.css">
+    <link rel="icon" type="image/png" href="/assets/ember.ico">
 
     
   </head>
   <body>
-    
 
-    <script src="/ui/assets/vendor-efed152f664f9c2069478d5ed32bbf51.js"></script>
-    <script src="/ui/assets/ember-realworld-2e28dcaa9120be6d6a7fd97eaf79424f.js"></script>
-
+    <script src="/assets/vendor-efed152f664f9c2069478d5ed32bbf51.js"></script>
+    <script src="/assets/ember-realworld-2e28dcaa9120be6d6a7fd97eaf79424f.js"></script>
     
   </body>
 </html>

--- a/webgear-example-realworld/webgear-example-realworld.cabal
+++ b/webgear-example-realworld/webgear-example-realworld.cabal
@@ -28,7 +28,6 @@ executable realworld
                     , http-types
                     , jose
                     , lens
-                    , mime-types
                     , monad-logger
                     , monad-time
                     , mtl
@@ -43,6 +42,7 @@ executable realworld
                     , time
                     , uri-encode
                     , wai
+                    , wai-app-static
                     , warp
                     , webgear-server
                     , webgear-openapi

--- a/webgear-server/CHANGELOG.md
+++ b/webgear-server/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Support for embedding WAI applications in handlers (#36)
+
 ## [1.1.1] - 2024-01-01
 
 ### Changed

--- a/webgear-server/src/WebGear/Server/Trait/Status.hs
+++ b/webgear-server/src/WebGear/Server/Trait/Status.hs
@@ -5,7 +5,7 @@ module WebGear.Server.Trait.Status where
 
 import Control.Arrow (returnA)
 import qualified Network.HTTP.Types.Status as HTTP
-import WebGear.Core.Response (Response (responseStatus))
+import WebGear.Core.Response (Response (..))
 import WebGear.Core.Trait (Set, With, setTrait, unwitness)
 import WebGear.Core.Trait.Status (Status (..))
 import WebGear.Server.Handler (ServerHandler)
@@ -16,6 +16,9 @@ instance (Monad m) => Set (ServerHandler m) Status Response where
     Status ->
     (Response `With` ts -> Response -> HTTP.Status -> Response `With` (Status : ts)) ->
     ServerHandler m (Response `With` ts, HTTP.Status) (Response `With` (Status : ts))
-  setTrait (Status status) f = proc (response, _) -> do
-    let response' = (unwitness response){responseStatus = status}
-    returnA -< f response response' status
+  setTrait (Status status) f = proc (wResponse, _) -> do
+    let response' =
+          case unwitness wResponse of
+            Response _ hdrs body -> Response status hdrs body
+            response -> response
+    returnA -< f wResponse response' status

--- a/webgear-swagger-ui/CHANGELOG.md
+++ b/webgear-swagger-ui/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Support for embedding WAI applications in handlers (#36)
+
 ## [1.1.1] - 2024-01-01
 
 ### Changed

--- a/webgear-swagger-ui/webgear-swagger-ui.cabal
+++ b/webgear-swagger-ui/webgear-swagger-ui.cabal
@@ -55,6 +55,7 @@ library
                     , http-types ==0.12.*
                     , mime-types ==0.1.*
                     , text >=1.2.0.0 && <2.2
+                    , wai-app-static ==3.1.*
                     , webgear-core ^>=1.1.1
   default-extensions: Arrows
                       DataKinds


### PR DESCRIPTION
- Enhances the response type to include WAI raw applications and continuation based applications.
- Use `wai-app-static` to serve static assets
- Removed `serveFile`. Can use `wai-app-static` as a replacement.