### PR TITLE
Remove dependency on bytestring-conversion

### DIFF
--- a/nix/overlays/haskell.nix
+++ b/nix/overlays/haskell.nix
@@ -42,9 +42,6 @@ let
             servant = hsLib.dontHaddock (hfinal.callPackage ../haskell-packages/servant.nix {});
             servant-server = hsLib.dontHaddock (hfinal.callPackage ../haskell-packages/servant-server.nix {});
 
-            # No longer broken
-            bytestring-conversion = hsLib.unmarkBroken hprev.bytestring-conversion;
-
             # doctests fail
             openapi3 = hsLib.dontCheck (hsLib.unmarkBroken hprev.openapi3);
 
@@ -61,9 +58,6 @@ let
             servant = hsLib.dontHaddock (hfinal.callPackage ../haskell-packages/servant.nix {});
             servant-server = hsLib.dontHaddock (hfinal.callPackage ../haskell-packages/servant-server.nix {});
 
-            # No longer broken
-            bytestring-conversion = hsLib.unmarkBroken hprev.bytestring-conversion;
-
             # doctests fail
             openapi3 = hsLib.dontCheck (hsLib.unmarkBroken hprev.openapi3);
           };
@@ -76,9 +70,6 @@ let
             scotty = hsLib.dontHaddock (hfinal.callPackage ../haskell-packages/scotty.nix {});
             servant = hsLib.dontHaddock (hfinal.callPackage ../haskell-packages/servant.nix {});
             servant-server = hsLib.dontHaddock (hfinal.callPackage ../haskell-packages/servant-server.nix {});
-
-            # No longer broken
-            bytestring-conversion = hsLib.unmarkBroken hprev.bytestring-conversion;
 
             # doctests fail
             openapi3 = hsLib.dontCheck (hsLib.unmarkBroken hprev.openapi3);
@@ -93,9 +84,6 @@ let
             servant = hsLib.dontHaddock (hfinal.callPackage ../haskell-packages/servant.nix {});
             servant-server = hsLib.dontHaddock (hfinal.callPackage ../haskell-packages/servant-server.nix {});
 
-            # No longer broken
-            bytestring-conversion = hsLib.unmarkBroken hprev.bytestring-conversion;
-
             # doctests fail
             openapi3 = hsLib.dontCheck (hsLib.unmarkBroken hprev.openapi3);
           };
@@ -108,9 +96,6 @@ let
             scotty = hsLib.dontHaddock (hfinal.callPackage ../haskell-packages/scotty.nix {});
             servant = hsLib.dontHaddock (hfinal.callPackage ../haskell-packages/servant.nix {});
             servant-server = hsLib.dontHaddock (hfinal.callPackage ../haskell-packages/servant-server.nix {});
-
-            # No longer broken
-            bytestring-conversion = hsLib.unmarkBroken hprev.bytestring-conversion;
 
             # doctests fail
             openapi3 = hsLib.dontCheck (hsLib.unmarkBroken hprev.openapi3);

--- a/stack-8.10.7.yaml.lock
+++ b/stack-8.10.7.yaml.lock
@@ -5,26 +5,26 @@
 
 packages:
 - completed:
-    hackage: scotty-0.12.1@sha256:ba1b01d21b0ba3c65bdd82961b22710350158c8edd7943bd14c02a364ade8412,5437
+    hackage: scotty-0.20.1@sha256:f51d7062b2732115cb8b9c63ded0c7a94467ee4fc68ebbde18687a836b74bcd5,5226
     pantry-tree:
-      sha256: 5e3491c30482946ccd2bc3a03a8558e1d38d1902779783bb3cd8b39920532a01
-      size: 1701
+      sha256: 0a42c300e7e5ed06fba6216f28b3c67be3d46fafba9b68957786fb52d6517a3b
+      size: 1945
   original:
-    hackage: scotty-0.12.1@sha256:ba1b01d21b0ba3c65bdd82961b22710350158c8edd7943bd14c02a364ade8412,5437
+    hackage: scotty-0.20.1@sha256:f51d7062b2732115cb8b9c63ded0c7a94467ee4fc68ebbde18687a836b74bcd5,5226
 - completed:
-    hackage: servant-0.19.1@sha256:4a9673b01b42d028f21bc40ea5416b0cdc6d5ca02520fe808f98386882f0b3f0,5564
+    hackage: servant-0.20.1@sha256:ec6b11132f3448a0f7daa6b3d0daf2634062017df89855c6b9d8268944c72243,5436
     pantry-tree:
-      sha256: a330b96027c37f85357b9e1603a29c6e765b9dfc5e4b19bee4027e87066433da
-      size: 2802
+      sha256: 1d165bc7ebf50280ba39191112eba0368bb9af55b7345bc17318fdcf803efdba
+      size: 2873
   original:
-    hackage: servant-0.19.1@sha256:4a9673b01b42d028f21bc40ea5416b0cdc6d5ca02520fe808f98386882f0b3f0,5564
+    hackage: servant-0.20.1@sha256:ec6b11132f3448a0f7daa6b3d0daf2634062017df89855c6b9d8268944c72243,5436
 - completed:
-    hackage: servant-server-0.19.2@sha256:a300e17d1c779ea404be0af84dfda3b996825afa6b429c0f8cb490cdeceb7ec7,5709
+    hackage: servant-server-0.20@sha256:1bb179f028b0b2b28222f04bd589f9fbc6f855194e73a7cbc692e097f3b30574,5739
     pantry-tree:
-      sha256: aeacefa2fad27eef606c5dbb7339e233ca148eb4c3c986c8409e5f23cfdbfa58
-      size: 2614
+      sha256: 8ae235fc825018111ecfeb74fe63753010ed4585a1fc391422b8083ce3ba3ae8
+      size: 2615
   original:
-    hackage: servant-server-0.19.2@sha256:a300e17d1c779ea404be0af84dfda3b996825afa6b429c0f8cb490cdeceb7ec7,5709
+    hackage: servant-server-0.20@sha256:1bb179f028b0b2b28222f04bd589f9fbc6f855194e73a7cbc692e097f3b30574,5739
 snapshots:
 - completed:
     sha256: 428ec8d5ce932190d3cbe266b9eb3c175cd81e984babf876b64019e2cbe4ea68

--- a/stack-9.0.2.yaml.lock
+++ b/stack-9.0.2.yaml.lock
@@ -5,12 +5,26 @@
 
 packages:
 - completed:
-    hackage: scotty-0.12.1@sha256:ba1b01d21b0ba3c65bdd82961b22710350158c8edd7943bd14c02a364ade8412,5437
+    hackage: scotty-0.20.1@sha256:f51d7062b2732115cb8b9c63ded0c7a94467ee4fc68ebbde18687a836b74bcd5,5226
     pantry-tree:
-      sha256: 5e3491c30482946ccd2bc3a03a8558e1d38d1902779783bb3cd8b39920532a01
-      size: 1701
+      sha256: 0a42c300e7e5ed06fba6216f28b3c67be3d46fafba9b68957786fb52d6517a3b
+      size: 1945
   original:
-    hackage: scotty-0.12.1@sha256:ba1b01d21b0ba3c65bdd82961b22710350158c8edd7943bd14c02a364ade8412,5437
+    hackage: scotty-0.20.1@sha256:f51d7062b2732115cb8b9c63ded0c7a94467ee4fc68ebbde18687a836b74bcd5,5226
+- completed:
+    hackage: servant-0.20.1@sha256:ec6b11132f3448a0f7daa6b3d0daf2634062017df89855c6b9d8268944c72243,5436
+    pantry-tree:
+      sha256: 1d165bc7ebf50280ba39191112eba0368bb9af55b7345bc17318fdcf803efdba
+      size: 2873
+  original:
+    hackage: servant-0.20.1@sha256:ec6b11132f3448a0f7daa6b3d0daf2634062017df89855c6b9d8268944c72243,5436
+- completed:
+    hackage: servant-server-0.20@sha256:1bb179f028b0b2b28222f04bd589f9fbc6f855194e73a7cbc692e097f3b30574,5739
+    pantry-tree:
+      sha256: 8ae235fc825018111ecfeb74fe63753010ed4585a1fc391422b8083ce3ba3ae8
+      size: 2615
+  original:
+    hackage: servant-server-0.20@sha256:1bb179f028b0b2b28222f04bd589f9fbc6f855194e73a7cbc692e097f3b30574,5739
 snapshots:
 - completed:
     sha256: 6d1532d40621957a25bad5195bfca7938e8a06d923c91bc52aa0f3c41181f2d4

--- a/stack-9.2.8.yaml.lock
+++ b/stack-9.2.8.yaml.lock
@@ -3,7 +3,28 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: scotty-0.20.1@sha256:f51d7062b2732115cb8b9c63ded0c7a94467ee4fc68ebbde18687a836b74bcd5,5226
+    pantry-tree:
+      sha256: 0a42c300e7e5ed06fba6216f28b3c67be3d46fafba9b68957786fb52d6517a3b
+      size: 1945
+  original:
+    hackage: scotty-0.20.1@sha256:f51d7062b2732115cb8b9c63ded0c7a94467ee4fc68ebbde18687a836b74bcd5,5226
+- completed:
+    hackage: servant-0.20.1@sha256:ec6b11132f3448a0f7daa6b3d0daf2634062017df89855c6b9d8268944c72243,5436
+    pantry-tree:
+      sha256: 1d165bc7ebf50280ba39191112eba0368bb9af55b7345bc17318fdcf803efdba
+      size: 2873
+  original:
+    hackage: servant-0.20.1@sha256:ec6b11132f3448a0f7daa6b3d0daf2634062017df89855c6b9d8268944c72243,5436
+- completed:
+    hackage: servant-server-0.20@sha256:1bb179f028b0b2b28222f04bd589f9fbc6f855194e73a7cbc692e097f3b30574,5739
+    pantry-tree:
+      sha256: 8ae235fc825018111ecfeb74fe63753010ed4585a1fc391422b8083ce3ba3ae8
+      size: 2615
+  original:
+    hackage: servant-server-0.20@sha256:1bb179f028b0b2b28222f04bd589f9fbc6f855194e73a7cbc692e097f3b30574,5739
 snapshots:
 - completed:
     sha256: 5a59b2a405b3aba3c00188453be172b85893cab8ebc352b1ef58b0eae5d248a2

--- a/stack-9.4.8.yaml
+++ b/stack-9.4.8.yaml
@@ -9,7 +9,6 @@ packages:
   - ./webgear-benchmarks
 
 extra-deps:
-  - bytestring-conversion-0.3.2@sha256:156804ee1178e1d57a4c834968a1f70ba490a158fad410771910bd0be6444122,2546
   - scotty-0.20.1@sha256:c6c38727407c1e925ba44b55686f7a18526dbddb138317eb637a1cb1df3cff09,5382
   - servant-0.20.1@sha256:3f0850b019cfcb66501048e6e881a005b2decfee9abb36efc8a2bb5e4f76fe8c,5626
   - servant-server-0.20@sha256:6f312610f197b0162dc198250c553c9bcfeeb8d2f960929909a1d21e278d37f8,5739

--- a/stack-9.4.8.yaml.lock
+++ b/stack-9.4.8.yaml.lock
@@ -5,12 +5,26 @@
 
 packages:
 - completed:
-    hackage: bytestring-conversion-0.3.2@sha256:156804ee1178e1d57a4c834968a1f70ba490a158fad410771910bd0be6444122,2546
+    hackage: scotty-0.20.1@sha256:c6c38727407c1e925ba44b55686f7a18526dbddb138317eb637a1cb1df3cff09,5382
     pantry-tree:
-      sha256: f0a7c09ece25d568dbb832b11b7f5c105e40e4fc7faf0be4d3c363a67aaf9bbd
-      size: 700
+      sha256: e2380abbb22fbd384f54543689b972c97c942ab3a0a506661f70213d5b81b5d2
+      size: 1945
   original:
-    hackage: bytestring-conversion-0.3.2@sha256:156804ee1178e1d57a4c834968a1f70ba490a158fad410771910bd0be6444122,2546
+    hackage: scotty-0.20.1@sha256:c6c38727407c1e925ba44b55686f7a18526dbddb138317eb637a1cb1df3cff09,5382
+- completed:
+    hackage: servant-0.20.1@sha256:3f0850b019cfcb66501048e6e881a005b2decfee9abb36efc8a2bb5e4f76fe8c,5626
+    pantry-tree:
+      sha256: d8a0d5a18e42b5c187f262f1f96a197721ab6cf385347ecfd1b47f422a732717
+      size: 2873
+  original:
+    hackage: servant-0.20.1@sha256:3f0850b019cfcb66501048e6e881a005b2decfee9abb36efc8a2bb5e4f76fe8c,5626
+- completed:
+    hackage: servant-server-0.20@sha256:6f312610f197b0162dc198250c553c9bcfeeb8d2f960929909a1d21e278d37f8,5739
+    pantry-tree:
+      sha256: 0daca40197be74f3eb61a636a7edeaa300abbe0f9be6d022fad77c309a39f841
+      size: 2615
+  original:
+    hackage: servant-server-0.20@sha256:6f312610f197b0162dc198250c553c9bcfeeb8d2f960929909a1d21e278d37f8,5739
 snapshots:
 - completed:
     sha256: a81fb3877c4f9031e1325eb3935122e608d80715dc16b586eb11ddbff8671ecd

--- a/webgear-server/CHANGELOG.md
+++ b/webgear-server/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Prerequisite traits (#37)
 
 ### Changed
+- Removed the dependency on bytestring-conversion package (#38)
 - Support for embedding WAI applications in handlers (#36)
 
 ## [1.1.1] - 2024-01-01

--- a/webgear-server/src/WebGear/Server/MIMETypes.hs
+++ b/webgear-server/src/WebGear/Server/MIMETypes.hs
@@ -74,7 +74,7 @@ instance (MonadIO m) => BodyUnrender m HTML BS.ByteString where
   bodyUnrender :: HTML -> Request -> m (Either Text BS.ByteString)
   bodyUnrender _ request = do
     body <- liftIO $ getRequestBody request
-    pure $ Right $ BS.toStrict body
+    pure $ Right $ LBS.toStrict body
 
 instance (Monad m) => BodyRender m HTML BS.ByteString where
   bodyRender :: HTML -> Response -> BS.ByteString -> m (HTTP.MediaType, ResponseBody)
@@ -133,7 +133,7 @@ instance (MonadIO m) => BodyUnrender m OctetStream BS.ByteString where
   bodyUnrender :: OctetStream -> Request -> m (Either Text BS.ByteString)
   bodyUnrender _ request = do
     body <- liftIO $ getRequestBody request
-    pure $ Right $ BS.toStrict body
+    pure $ Right $ LBS.toStrict body
 
 instance (Monad m) => BodyRender m OctetStream BS.ByteString where
   bodyRender :: OctetStream -> Response -> BS.ByteString -> m (HTTP.MediaType, ResponseBody)

--- a/webgear-server/src/WebGear/Server/Trait/Cookie.hs
+++ b/webgear-server/src/WebGear/Server/Trait/Cookie.hs
@@ -4,8 +4,8 @@
 module WebGear.Server.Trait.Cookie () where
 
 import Control.Arrow (arr, returnA, (>>>))
-import Data.ByteString (ByteString)
-import Data.ByteString.Conversion (toByteString')
+import Data.Binary.Builder (toLazyByteString)
+import Data.ByteString (ByteString, toStrict)
 import Data.Proxy (Proxy (Proxy))
 import Data.String (fromString)
 import Data.Text (Text)
@@ -101,6 +101,7 @@ alterCookie name Nothing hdrs = filter (not . isMatchingCookie) hdrs
 
 cookieToBS :: ByteString -> Cookie.SetCookie -> ByteString
 cookieToBS name cookie =
-  toByteString' $
-    Cookie.renderSetCookie $
-      cookie{Cookie.setCookieName = name}
+  toStrict $
+    toLazyByteString $
+      Cookie.renderSetCookie $
+        cookie{Cookie.setCookieName = name}

--- a/webgear-server/src/WebGear/Server/Trait/Cookie.hs
+++ b/webgear-server/src/WebGear/Server/Trait/Cookie.hs
@@ -5,7 +5,8 @@ module WebGear.Server.Trait.Cookie () where
 
 import Control.Arrow (arr, returnA, (>>>))
 import Data.Binary.Builder (toLazyByteString)
-import Data.ByteString (ByteString, toStrict)
+import Data.ByteString (ByteString)
+import Data.ByteString.Lazy (toStrict)
 import Data.Proxy (Proxy (Proxy))
 import Data.String (fromString)
 import Data.Text (Text)

--- a/webgear-server/webgear-server.cabal
+++ b/webgear-server/webgear-server.cabal
@@ -97,7 +97,6 @@ library
   build-depends:      aeson >=1.4 && <1.6 || >=2.0 && <2.3
                     , arrows ==0.4.*
                     , binary >= 0.8.0.0 && <0.9
-                    , bytestring-conversion ==0.3.*
                     , cookie >=0.4.5 && <0.5
                     , http-api-data >=0.4.2 && <0.7
                     , http-media ==0.8.*

--- a/webgear-swagger-ui/src/WebGear/Swagger/UI.hs
+++ b/webgear-swagger-ui/src/WebGear/Swagger/UI.hs
@@ -9,7 +9,6 @@ import Control.Arrow ((<+>))
 import Data.ByteString (ByteString)
 import Data.Text (Text)
 import qualified Network.HTTP.Types as HTTP
-import qualified Network.Mime as Mime
 import Network.Wai.Application.Static (embeddedSettings)
 import WebGear.Core (
   Body,
@@ -42,7 +41,6 @@ swaggerUI ::
   , Sets
       h
       [ RequiredResponseHeader "Content-Type" Text
-      , RequiredResponseHeader "Content-Type" Mime.MimeType
       , Body HTML ByteString
       , Body JSON apiSpec
       , UnknownContentBody

--- a/webgear-swagger-ui/webgear-swagger-ui.cabal
+++ b/webgear-swagger-ui/webgear-swagger-ui.cabal
@@ -53,7 +53,6 @@ library
                     , bytestring >=0.10.10.1 && <0.13
                     , file-embed ==0.0.*
                     , http-types ==0.12.*
-                    , mime-types ==0.1.*
                     , text >=1.2.0.0 && <2.2
                     , wai-app-static ==3.1.*
                     , webgear-core ^>=1.1.1


### PR DESCRIPTION
This package is broken on latest stackage snapshots. Besides, it is not strictly required by webgear.