### PR TITLE
Simplify core API (breaking change)

### DIFF
--- a/webgear-benchmarks/src/users/WebGear.hs
+++ b/webgear-benchmarks/src/users/WebGear.hs
@@ -18,23 +18,23 @@ type UserIdPathVar = PathVar "userId" Int
 
 allRoutes ::
   ( StdHandler h AppM
-  , Gets h [UserIdPathVar, Body JSON User] Request
-  , Sets h [RequiredResponseHeader "Content-Type" Text, Body JSON User] Response
+  , Gets h [UserIdPathVar, Body JSON User]
+  , Set h (Body JSON User)
   ) =>
   h (Request `With` '[]) Response
 allRoutes =
   -- Non-TH version:
   --   path "/v1/users" $ pathVar @"userId" @Int $ pathEnd
-  [route| /v1/users/userId:Int |]
-    $ method GET getUser
-    <+> method PUT putUser
-    <+> method DELETE deleteUser
+  [route| /v1/users/userId:Int |] $
+    method GET getUser
+      <+> method PUT putUser
+      <+> method DELETE deleteUser
 
 getUser ::
   forall h ts.
   ( HasTrait UserIdPathVar ts
   , StdHandler h AppM
-  , Sets h [RequiredResponseHeader "Content-Type" Text, Body JSON User] Response
+  , Set h (Body JSON User)
   ) =>
   h (Request `With` ts) Response
 getUser = findUser >>> respond
@@ -54,8 +54,8 @@ putUser ::
   forall h ts.
   ( HasTrait UserIdPathVar ts
   , StdHandler h AppM
-  , Get h (Body JSON User) Request
-  , Sets h [RequiredResponseHeader "Content-Type" Text, Body JSON User] Response
+  , Get h (Body JSON User)
+  , Set h (Body JSON User)
   ) =>
   h (Request `With` ts) Response
 putUser = requestBody @User JSON badPayload $ doUpdate >>> respond

--- a/webgear-core/CHANGELOG.md
+++ b/webgear-core/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Simplify core API (breaking change) (#47)
+
 ## [1.2.0] - 2024-03-18
 
 ### Added

--- a/webgear-core/src/WebGear/Core/Trait.hs
+++ b/webgear-core/src/WebGear/Core/Trait.hs
@@ -3,8 +3,7 @@
 {- | Traits are optional attributes associated with a value. For
  example, a list containing totally ordered values might have a
  @Maximum@ trait where the associated attribute is the maximum
- value. This trait exists only if the list is non-empty. The 'Trait'
- typeclass provides an interface to extract such trait attributes.
+ value. This trait exists only if the list is non-empty.
 
  Traits help to associate attributes with values in a type-safe
  manner.
@@ -45,8 +44,8 @@
 -}
 module WebGear.Core.Trait (
   -- * Core Types
-  Trait (..),
-  TraitAbsence (..),
+  Attribute,
+  Absence,
   Prerequisite,
   Get (..),
   Gets,
@@ -73,17 +72,12 @@ import Data.Kind (Constraint, Type)
 import Data.Tagged (Tagged (..), untag)
 import GHC.TypeLits (ErrorMessage (..), TypeError)
 
--- | A trait is an attribute @t@ associated with a value @a@.
-class Trait (t :: Type) a where
-  -- | Type of the associated attribute when the trait holds for a
-  -- value
-  type Attribute t a :: Type
+-- | Type of the associated attribute when the trait holds for a value
+type family Attribute t a :: Type
 
--- | A trait @t@ that can be retrieved from @a@ but could be absent.
-class (Trait t a) => TraitAbsence t a where
-  -- | Type that indicates that the trait does not exist for a
-  -- value. This could be an error message, exception etc.
-  type Absence t a :: Type
+-- | Type that indicates that the trait does not exist for a
+-- value. This could be an error message, exception etc.
+type family Absence t a :: Type
 
 {- | Indicates the constraints a trait depends upon as a
 prerequisite. This is used to assert that a trait @t@ can be
@@ -96,7 +90,7 @@ empty contraint @()@.
 type family Prerequisite (t :: Type) (ts :: [Type]) (a :: Type) :: Constraint
 
 -- | Extract trait attributes from a value.
-class (Arrow h, TraitAbsence t a) => Get h t a where
+class (Arrow h) => Get h t a where
   -- | Attempt to witness the trait attribute from the value @a@.
   getTrait ::
     (Prerequisite t ts a) =>
@@ -107,7 +101,7 @@ class (Arrow h, TraitAbsence t a) => Get h t a where
     h (a `With` ts) (Either (Absence t a) (Attribute t a))
 
 -- | Associate a trait attribute on a value
-class (Arrow h, Trait t a) => Set h (t :: Type) a where
+class (Arrow h) => Set h (t :: Type) a where
   -- | Set a trait attribute @t@ on the value @a \`With\` ts@.
   setTrait ::
     -- | The trait to set

--- a/webgear-core/src/WebGear/Core/Trait/Auth/Basic.hs
+++ b/webgear-core/src/WebGear/Core/Trait/Auth/Basic.hs
@@ -124,17 +124,13 @@ data BasicAuthError e
   | BasicAuthAttributeError e
   deriving stock (Eq, Show, Read)
 
-instance Trait (BasicAuth' Required scheme m e a) Request where
-  type Attribute (BasicAuth' Required scheme m e a) Request = a
+type instance Attribute (BasicAuth' Required scheme m e a) Request = a
 
-instance TraitAbsence (BasicAuth' Required scheme m e a) Request where
-  type Absence (BasicAuth' Required scheme m e a) Request = BasicAuthError e
+type instance Absence (BasicAuth' Required scheme m e a) Request = BasicAuthError e
 
-instance Trait (BasicAuth' Optional scheme m e a) Request where
-  type Attribute (BasicAuth' Optional scheme m e a) Request = Either (BasicAuthError e) a
+type instance Attribute (BasicAuth' Optional scheme m e a) Request = Either (BasicAuthError e) a
 
-instance TraitAbsence (BasicAuth' Optional scheme m e a) Request where
-  type Absence (BasicAuth' Optional scheme m e a) Request = Void
+type instance Absence (BasicAuth' Optional scheme m e a) Request = Void
 
 type instance
   Prerequisite (BasicAuth' x scheme m e a) ts Request =

--- a/webgear-core/src/WebGear/Core/Trait/Auth/Basic.hs
+++ b/webgear-core/src/WebGear/Core/Trait/Auth/Basic.hs
@@ -32,9 +32,14 @@
  authConfig :: 'BasicAuth' IO () 'Credentials'
  authConfig = 'BasicAuth'' { toBasicAttribute = pure . Right }
 
- type ErrorTraits = [Status, RequiredRequestHeader \"Content-Type\" Text, RequiredRequestHeader \"WWW-Authenticate\" Text, Body Text]
+ type ErrorTraits =
+  [ Status
+  , RequiredResponseHeader \"Content-Type\" Text
+  , RequiredResponseHeader \"WWW-Authenticate\" Text
+  , Body Text
+  ]
 
- errorHandler :: ('Handler' h IO, Sets h ErrorTraits Response)
+ errorHandler :: ('Handler' h IO, Sets h ErrorTraits)
               => h (Request \`With\` ts, 'BasicAuthError' e) Response
  errorHandler = 'respondUnauthorized' \"Basic\" \"MyRealm\"
  @
@@ -42,7 +47,7 @@
  we can add basic authentication to @myHandler@:
 
  @
- myHandlerWithAuth :: ('Handler' h IO, Get h ('BasicAuth' IO () 'Credentials') Request, Sets h ErrorTraits Response)
+ myHandlerWithAuth :: ('Handler' h IO, Get h ('BasicAuth' IO () 'Credentials'), Sets h ErrorTraits)
                    => 'RequestHandler' h ts
  myHandlerWithAuth = 'basicAuth' authConfig errorHandler myHandler
  @
@@ -125,24 +130,22 @@ data BasicAuthError e
   deriving stock (Eq, Show, Read)
 
 type instance Attribute (BasicAuth' Required scheme m e a) Request = a
-
-type instance Absence (BasicAuth' Required scheme m e a) Request = BasicAuthError e
+type instance Absence (BasicAuth' Required scheme m e a) = BasicAuthError e
 
 type instance Attribute (BasicAuth' Optional scheme m e a) Request = Either (BasicAuthError e) a
-
-type instance Absence (BasicAuth' Optional scheme m e a) Request = Void
+type instance Absence (BasicAuth' Optional scheme m e a) = Void
 
 type instance
-  Prerequisite (BasicAuth' x scheme m e a) ts Request =
+  Prerequisite (BasicAuth' x scheme m e a) ts =
     HasTrait (AuthorizationHeader scheme) ts
 
 basicAuthMiddleware ::
   ( ArrowChoice h
-  , Get h (BasicAuth' x scheme m e t) Request
+  , Get h (BasicAuth' x scheme m e t)
   , HasTrait (AuthorizationHeader scheme) ts
   ) =>
   BasicAuth' x scheme m e t ->
-  h (Request `With` ts, Absence (BasicAuth' x scheme m e t) Request) Response ->
+  h (Request `With` ts, Absence (BasicAuth' x scheme m e t)) Response ->
   Middleware h ts (BasicAuth' x scheme m e t : ts)
 basicAuthMiddleware authCfg errorHandler nextHandler =
   proc request -> do
@@ -165,7 +168,7 @@ basicAuthMiddleware authCfg errorHandler nextHandler =
 basicAuth ::
   forall m e t h ts.
   ( ArrowChoice h
-  , Get h (BasicAuth' Required "Basic" m e t) Request
+  , Get h (BasicAuth' Required "Basic" m e t)
   , HasTrait (AuthorizationHeader "Basic") ts
   ) =>
   -- | Authentication configuration
@@ -185,7 +188,7 @@ basicAuth = basicAuth'
 basicAuth' ::
   forall scheme m e t h ts.
   ( ArrowChoice h
-  , Get h (BasicAuth' Required scheme m e t) Request
+  , Get h (BasicAuth' Required scheme m e t)
   , HasTrait (AuthorizationHeader scheme) ts
   ) =>
   -- | Authentication configuration
@@ -210,7 +213,7 @@ basicAuth' = basicAuthMiddleware
 optionalBasicAuth ::
   forall m e t h ts.
   ( ArrowChoice h
-  , Get h (BasicAuth' Optional "Basic" m e t) Request
+  , Get h (BasicAuth' Optional "Basic" m e t)
   , HasTrait (AuthorizationHeader "Basic") ts
   ) =>
   -- | Authentication configuration
@@ -229,7 +232,7 @@ optionalBasicAuth = optionalBasicAuth'
 optionalBasicAuth' ::
   forall scheme m e t h ts.
   ( ArrowChoice h
-  , Get h (BasicAuth' Optional scheme m e t) Request
+  , Get h (BasicAuth' Optional scheme m e t)
   , HasTrait (AuthorizationHeader scheme) ts
   ) =>
   -- | Authentication configuration

--- a/webgear-core/src/WebGear/Core/Trait/Auth/Common.hs
+++ b/webgear-core/src/WebGear/Core/Trait/Auth/Common.hs
@@ -72,7 +72,6 @@ respondUnauthorized ::
       , RequiredResponseHeader "WWW-Authenticate" Text
       , Body PlainText Text
       ]
-      Response
   ) =>
   -- | The authentication scheme
   CI ByteString ->

--- a/webgear-core/src/WebGear/Core/Trait/Auth/JWT.hs
+++ b/webgear-core/src/WebGear/Core/Trait/Auth/JWT.hs
@@ -36,9 +36,14 @@
    , toJWTAttribute = pure . Right
    }
 
- type ErrorTraits = [Status, RequiredRequestHeader \"Content-Type\" Text, RequiredRequestHeader \"WWW-Authenticate\" Text, Body Text]
+ type ErrorTraits =
+  [ Status
+  , RequiredResponseHeader \"Content-Type\" Text
+  , RequiredResponseHeader \"WWW-Authenticate\" Text
+  , Body Text
+  ]
 
- errorHandler :: ('Handler' h IO, Sets h ErrorTraits Response)
+ errorHandler :: ('Handler' h IO, Sets h ErrorTraits)
               => h (Request \`With\` ts, 'JWTAuthError' e) Response
  errorHandler = 'respondUnauthorized' \"Bearer\" \"MyRealm\"
  @
@@ -46,7 +51,7 @@
  we can add JWT authentication to @myHandler@:
 
  @
- myHandlerWithAuth :: ('Handler' h IO, Get h ('JWTAuth' IO () 'JWT.ClaimsSet') Request, Sets h ErrorTraits Response)
+ myHandlerWithAuth :: ('Handler' h IO, Get h ('JWTAuth' IO () 'JWT.ClaimsSet'), Sets h ErrorTraits)
                    => 'RequestHandler' h ts
  myHandlerWithAuth = 'jwtAuth' authConfig errorHandler myHandler
  @
@@ -117,15 +122,13 @@ data JWTAuthError e
   deriving stock (Eq, Show)
 
 type instance Attribute (JWTAuth' Required scheme m e a) Request = a
-
-type instance Absence (JWTAuth' Required scheme m e a) Request = JWTAuthError e
+type instance Absence (JWTAuth' Required scheme m e a) = JWTAuthError e
 
 type instance Attribute (JWTAuth' Optional scheme m e a) Request = Either (JWTAuthError e) a
-
-type instance Absence (JWTAuth' Optional scheme m e a) Request = Void
+type instance Absence (JWTAuth' Optional scheme m e a) = Void
 
 type instance
-  Prerequisite (JWTAuth' x scheme m e a) ts Request =
+  Prerequisite (JWTAuth' x scheme m e a) ts =
     HasTrait (AuthorizationHeader scheme) ts
 
 {- | Middleware to add JWT authentication protection for a
@@ -144,7 +147,7 @@ type instance
 -}
 jwtAuth ::
   ( ArrowChoice h
-  , Get h (JWTAuth m e t) Request
+  , Get h (JWTAuth m e t)
   , HasTrait (AuthorizationHeader "Bearer") ts
   ) =>
   -- | Authentication configuration
@@ -172,7 +175,7 @@ jwtAuth = jwtAuth' @"Bearer"
 -}
 optionalJWTAuth ::
   ( ArrowChoice h
-  , Get h (JWTAuth' Optional "Bearer" m e t) Request
+  , Get h (JWTAuth' Optional "Bearer" m e t)
   , HasTrait (AuthorizationHeader "Bearer") ts
   ) =>
   -- | Authentication configuration
@@ -184,11 +187,11 @@ optionalJWTAuth = optionalJWTAuth' @"Bearer"
 jwtAuthMiddleware ::
   forall scheme e t x h m ts.
   ( ArrowChoice h
-  , Get h (JWTAuth' x scheme m e t) Request
+  , Get h (JWTAuth' x scheme m e t)
   , HasTrait (AuthorizationHeader scheme) ts
   ) =>
   JWTAuth' x scheme m e t ->
-  h (Request `With` ts, Absence (JWTAuth' x scheme m e t) Request) Response ->
+  h (Request `With` ts, Absence (JWTAuth' x scheme m e t)) Response ->
   Middleware h ts (JWTAuth' x scheme m e t : ts)
 jwtAuthMiddleware authCfg errorHandler nextHandler =
   proc request -> do
@@ -215,7 +218,7 @@ jwtAuthMiddleware authCfg errorHandler nextHandler =
 jwtAuth' ::
   forall scheme e t h m ts.
   ( ArrowChoice h
-  , Get h (JWTAuth' Required scheme m e t) Request
+  , Get h (JWTAuth' Required scheme m e t)
   , HasTrait (AuthorizationHeader scheme) ts
   ) =>
   -- | Authentication configuration
@@ -244,7 +247,7 @@ jwtAuth' = jwtAuthMiddleware
 optionalJWTAuth' ::
   forall scheme e t h m ts.
   ( ArrowChoice h
-  , Get h (JWTAuth' Optional scheme m e t) Request
+  , Get h (JWTAuth' Optional scheme m e t)
   , HasTrait (AuthorizationHeader scheme) ts
   ) =>
   -- | Authentication configuration

--- a/webgear-core/src/WebGear/Core/Trait/Auth/JWT.hs
+++ b/webgear-core/src/WebGear/Core/Trait/Auth/JWT.hs
@@ -116,17 +116,13 @@ data JWTAuthError e
   | JWTAuthAttributeError e
   deriving stock (Eq, Show)
 
-instance Trait (JWTAuth' Required scheme m e a) Request where
-  type Attribute (JWTAuth' Required scheme m e a) Request = a
+type instance Attribute (JWTAuth' Required scheme m e a) Request = a
 
-instance TraitAbsence (JWTAuth' Required scheme m e a) Request where
-  type Absence (JWTAuth' Required scheme m e a) Request = JWTAuthError e
+type instance Absence (JWTAuth' Required scheme m e a) Request = JWTAuthError e
 
-instance Trait (JWTAuth' Optional scheme m e a) Request where
-  type Attribute (JWTAuth' Optional scheme m e a) Request = Either (JWTAuthError e) a
+type instance Attribute (JWTAuth' Optional scheme m e a) Request = Either (JWTAuthError e) a
 
-instance TraitAbsence (JWTAuth' Optional scheme m e a) Request where
-  type Absence (JWTAuth' Optional scheme m e a) Request = Void
+type instance Absence (JWTAuth' Optional scheme m e a) Request = Void
 
 type instance
   Prerequisite (JWTAuth' x scheme m e a) ts Request =

--- a/webgear-core/src/WebGear/Core/Trait/Body.hs
+++ b/webgear-core/src/WebGear/Core/Trait/Body.hs
@@ -1,17 +1,17 @@
 {- | Traits and middlewares to handle request and response body
    payloads.
 
- The 'requestBody' middleware attempts to convert the body to a
- Haskell value or invoke an error handler if that fails.
+   The 'requestBody' middleware attempts to convert the body to a
+   Haskell value or invoke an error handler if that fails.
 
- The 'respondA' middleware generates a response from an HTTP status
- and a response body.
+   The 'respondA' middleware generates a response from an HTTP status
+   and a response body.
 
- If you need finer control over setting the body, use 'setBody' or
- 'setBodyWithoutContentType'. These arrows accept a witnessed response
- and a body and sets the body in the response. You can generate an
- input response object using functions from
- "WebGear.Core.Trait.Status" module.
+   If you need finer control over setting the body, use 'setBody' or
+   'setBodyWithoutContentType'. These arrows accept a witnessed
+   response and a body and sets the body in the response. You can
+   generate an input response object using functions from
+   "WebGear.Core.Trait.Status" module.
 -}
 module WebGear.Core.Trait.Body (
   -- * Traits
@@ -36,12 +36,12 @@ import WebGear.Core.MIMETypes (MIMEType (..))
 import WebGear.Core.Request (Request)
 import WebGear.Core.Response (Response, ResponseBody)
 import WebGear.Core.Trait (
+  Absence,
+  Attribute,
   Get,
   Prerequisite,
   Set,
   Sets,
-  Attribute,
-  Absence,
   With (..),
   plant,
   probe,
@@ -53,10 +53,8 @@ import WebGear.Core.Trait.Status (Status, mkResponse)
 newtype Body (mimeType :: Type) (t :: Type) = Body mimeType
 
 type instance Attribute (Body mt t) Request = t
-
-type instance Absence (Body mt t) Request = Text
-
-type instance Prerequisite (Body mt t) ts Request = ()
+type instance Absence (Body mt t) = Text
+type instance Prerequisite (Body mt t) ts = ()
 
 type instance Attribute (Body mt t) Response = t
 
@@ -79,7 +77,7 @@ type instance Attribute UnknownContentBody Response = ResponseBody
 requestBody ::
   forall t mt h m ts.
   ( Handler h m
-  , Get h (Body mt t) Request
+  , Get h (Body mt t)
   ) =>
   mt ->
   -- | Error handler in case body cannot be retrieved
@@ -106,7 +104,7 @@ requestBody mt errorHandler nextHandler = proc request -> do
 -}
 setBody ::
   forall body mt h ts.
-  ( Sets h [Body mt body, RequiredResponseHeader "Content-Type" Text] Response
+  ( Sets h [Body mt body, RequiredResponseHeader "Content-Type" Text]
   , MIMEType mt
   ) =>
   mt ->
@@ -128,7 +126,7 @@ Usage:
 -}
 setBodyWithoutContentType ::
   forall h ts.
-  (Set h UnknownContentBody Response) =>
+  (Set h UnknownContentBody) =>
   h (Response `With` ts, ResponseBody) (Response `With` (UnknownContentBody : ts))
 setBodyWithoutContentType = plant UnknownContentBody
 {-# INLINE setBodyWithoutContentType #-}
@@ -147,7 +145,7 @@ setBodyWithoutContentType = plant UnknownContentBody
 respondA ::
   forall body mt h m.
   ( Handler h m
-  , Sets h [Status, Body mt body, RequiredResponseHeader "Content-Type" Text] Response
+  , Sets h [Status, Body mt body, RequiredResponseHeader "Content-Type" Text]
   , MIMEType mt
   ) =>
   -- | Response status

--- a/webgear-core/src/WebGear/Core/Trait/Body.hs
+++ b/webgear-core/src/WebGear/Core/Trait/Body.hs
@@ -40,8 +40,8 @@ import WebGear.Core.Trait (
   Prerequisite,
   Set,
   Sets,
-  Trait (..),
-  TraitAbsence (..),
+  Attribute,
+  Absence,
   With (..),
   plant,
   probe,
@@ -52,22 +52,18 @@ import WebGear.Core.Trait.Status (Status, mkResponse)
 -- | Request or response body with MIME types @mimeTypes@ and type @t@.
 newtype Body (mimeType :: Type) (t :: Type) = Body mimeType
 
-instance Trait (Body mt t) Request where
-  type Attribute (Body mt t) Request = t
+type instance Attribute (Body mt t) Request = t
 
-instance TraitAbsence (Body mt t) Request where
-  type Absence (Body mt t) Request = Text
+type instance Absence (Body mt t) Request = Text
 
 type instance Prerequisite (Body mt t) ts Request = ()
 
-instance Trait (Body mt t) Response where
-  type Attribute (Body mt t) Response = t
+type instance Attribute (Body mt t) Response = t
 
 -- | Type representing responses without a statically known MIME type
 data UnknownContentBody = UnknownContentBody
 
-instance Trait UnknownContentBody Response where
-  type Attribute UnknownContentBody Response = ResponseBody
+type instance Attribute UnknownContentBody Response = ResponseBody
 
 {- | Middleware to extract a request body.
 

--- a/webgear-core/src/WebGear/Core/Trait/Cookie.hs
+++ b/webgear-core/src/WebGear/Core/Trait/Cookie.hs
@@ -27,8 +27,8 @@ import WebGear.Core.Trait (
   HasTrait,
   Prerequisite,
   Set,
-  Trait (..),
-  TraitAbsence (..),
+  Attribute,
+  Absence,
   With,
   plant,
   probe,
@@ -46,21 +46,17 @@ newtype CookieParseError = CookieParseError Text
 -- | Trait for a cookie in HTTP requests
 data Cookie (e :: Existence) (name :: Symbol) (val :: Type) = Cookie
 
-instance Trait (Cookie Required name val) Request where
-  type Attribute (Cookie Required name val) Request = val
+type instance Attribute (Cookie Required name val) Request = val
 
 type instance
   Prerequisite (Cookie e name val) ts Request =
     HasTrait (RequestHeader e Strict "Cookie" Text) ts
 
-instance TraitAbsence (Cookie Required name val) Request where
-  type Absence (Cookie Required name val) Request = Either CookieNotFound CookieParseError
+type instance Absence (Cookie Required name val) Request = Either CookieNotFound CookieParseError
 
-instance Trait (Cookie Optional name val) Request where
-  type Attribute (Cookie Optional name val) Request = Maybe val
+type instance Attribute (Cookie Optional name val) Request = Maybe val
 
-instance TraitAbsence (Cookie Optional name val) Request where
-  type Absence (Cookie Optional name val) Request = CookieParseError
+type instance Absence (Cookie Optional name val) Request = CookieParseError
 
 cookieHandler ::
   forall name val e h ts.
@@ -122,11 +118,9 @@ optionalCookie = cookieHandler
 -- | Trait for a cookie in HTTP responses
 data SetCookie (e :: Existence) (name :: Symbol) = SetCookie
 
-instance Trait (SetCookie Required name) Response where
-  type Attribute (SetCookie Required name) Response = Cookie.SetCookie
+type instance Attribute (SetCookie Required name) Response = Cookie.SetCookie
 
-instance Trait (SetCookie Optional name) Response where
-  type Attribute (SetCookie Optional name) Response = Maybe Cookie.SetCookie
+type instance Attribute (SetCookie Optional name) Response = Maybe Cookie.SetCookie
 
 {- | Set a cookie value in a response.
 

--- a/webgear-core/src/WebGear/Core/Trait/Header.hs
+++ b/webgear-core/src/WebGear/Core/Trait/Header.hs
@@ -64,8 +64,8 @@ import WebGear.Core.Trait (
   Get (..),
   Prerequisite,
   Set,
-  Trait (..),
-  TraitAbsence (..),
+  Attribute,
+  Absence,
   With,
   plant,
   probe,
@@ -80,7 +80,7 @@ data HeaderNotFound = HeaderNotFound
 newtype HeaderParseError = HeaderParseError Text
   deriving stock (Read, Show, Eq)
 
-{- | A 'Trait' for capturing an HTTP header of specified @name@ and
+{- | A trait for capturing an HTTP header of specified @name@ and
  converting it to some type @val@. The modifiers @e@ and @p@ determine
  how missing headers and parsing errors are handled. The header name
  is compared case-insensitively.
@@ -93,29 +93,21 @@ type RequiredRequestHeader = RequestHeader Required Strict
 -- | A `RequestHeader` that is optional and parsed strictly
 type OptionalRequestHeader = RequestHeader Optional Strict
 
-instance Trait (RequestHeader Required Strict name val) Request where
-  type Attribute (RequestHeader Required Strict name val) Request = val
+type instance Attribute (RequestHeader Required Strict name val) Request = val
 
-instance TraitAbsence (RequestHeader Required Strict name val) Request where
-  type Absence (RequestHeader Required Strict name val) Request = Either HeaderNotFound HeaderParseError
+type instance Absence (RequestHeader Required Strict name val) Request = Either HeaderNotFound HeaderParseError
 
-instance Trait (RequestHeader Optional Strict name val) Request where
-  type Attribute (RequestHeader Optional Strict name val) Request = Maybe val
+type instance Attribute (RequestHeader Optional Strict name val) Request = Maybe val
 
-instance TraitAbsence (RequestHeader Optional Strict name val) Request where
-  type Absence (RequestHeader Optional Strict name val) Request = HeaderParseError
+type instance Absence (RequestHeader Optional Strict name val) Request = HeaderParseError
 
-instance Trait (RequestHeader Required Lenient name val) Request where
-  type Attribute (RequestHeader Required Lenient name val) Request = Either Text val
+type instance Attribute (RequestHeader Required Lenient name val) Request = Either Text val
 
-instance TraitAbsence (RequestHeader Required Lenient name val) Request where
-  type Absence (RequestHeader Required Lenient name val) Request = HeaderNotFound
+type instance Absence (RequestHeader Required Lenient name val) Request = HeaderNotFound
 
-instance Trait (RequestHeader Optional Lenient name val) Request where
-  type Attribute (RequestHeader Optional Lenient name val) Request = Maybe (Either Text val)
+type instance Attribute (RequestHeader Optional Lenient name val) Request = Maybe (Either Text val)
 
-instance TraitAbsence (RequestHeader Optional Lenient name val) Request where
-  type Absence (RequestHeader Optional Lenient name val) Request = Void
+type instance Absence (RequestHeader Optional Lenient name val) Request = Void
 
 type instance Prerequisite (RequestHeader e p name val) ts Request = ()
 
@@ -204,7 +196,7 @@ optionalLenientHeader ::
 optionalLenientHeader = headerHandler $ arr (absurd . snd)
 {-# INLINE optionalLenientHeader #-}
 
-{- | A 'Trait' for setting a header in the HTTP response. It has a
+{- | A trait for setting a header in the HTTP response. It has a
  specified @name@ and a value of type @val@. The header name is
  compared case-insensitively. The modifier @e@ determines whether the
  header is mandatory or optional.
@@ -217,11 +209,9 @@ type RequiredResponseHeader = ResponseHeader Required
 -- | A `ResponseHeader` that is optional
 type OptionalResponseHeader = ResponseHeader Optional
 
-instance Trait (ResponseHeader Required name val) Response where
-  type Attribute (ResponseHeader Required name val) Response = val
+type instance Attribute (ResponseHeader Required name val) Response = val
 
-instance Trait (ResponseHeader Optional name val) Response where
-  type Attribute (ResponseHeader Optional name val) Response = Maybe val
+type instance Attribute (ResponseHeader Optional name val) Response = Maybe val
 
 {- | Set a header value in a response.
 

--- a/webgear-core/src/WebGear/Core/Trait/Method.hs
+++ b/webgear-core/src/WebGear/Core/Trait/Method.hs
@@ -10,7 +10,7 @@ import Control.Arrow.Operations (ArrowError)
 import qualified Network.HTTP.Types as HTTP
 import WebGear.Core.Handler (Middleware, RouteMismatch, routeMismatch)
 import WebGear.Core.Request (Request)
-import WebGear.Core.Trait (Get (..), Prerequisite, Attribute, Absence, probe)
+import WebGear.Core.Trait (Absence, Attribute, Get (..), Prerequisite, probe)
 
 -- | A trait for capturing the HTTP method of a request
 newtype Method = Method HTTP.StdMethod
@@ -22,10 +22,8 @@ data MethodMismatch = MethodMismatch
   }
 
 type instance Attribute Method Request = HTTP.StdMethod
-
-type instance Absence Method Request = MethodMismatch
-
-type instance Prerequisite Method ts Request = ()
+type instance Absence Method = MethodMismatch
+type instance Prerequisite Method ts = ()
 
 {- | Check whether the request has a specified HTTP method.
 
@@ -41,7 +39,7 @@ type instance Prerequisite Method ts Request = ()
  cases where both an HTTP method and a path need to be matched.
 -}
 method ::
-  (Get h Method Request, ArrowChoice h, ArrowError RouteMismatch h) =>
+  (Get h Method, ArrowChoice h, ArrowError RouteMismatch h) =>
   HTTP.StdMethod ->
   Middleware h ts (Method : ts)
 method m nextHandler = probe (Method m) >>> routeMismatch ||| nextHandler

--- a/webgear-core/src/WebGear/Core/Trait/Method.hs
+++ b/webgear-core/src/WebGear/Core/Trait/Method.hs
@@ -10,9 +10,9 @@ import Control.Arrow.Operations (ArrowError)
 import qualified Network.HTTP.Types as HTTP
 import WebGear.Core.Handler (Middleware, RouteMismatch, routeMismatch)
 import WebGear.Core.Request (Request)
-import WebGear.Core.Trait (Get (..), Prerequisite, Trait (..), TraitAbsence (..), probe)
+import WebGear.Core.Trait (Get (..), Prerequisite, Attribute, Absence, probe)
 
--- | A 'Trait' for capturing the HTTP method of a request
+-- | A trait for capturing the HTTP method of a request
 newtype Method = Method HTTP.StdMethod
 
 -- | Failure to match method against an expected value
@@ -21,11 +21,9 @@ data MethodMismatch = MethodMismatch
   , actualMethod :: HTTP.Method
   }
 
-instance Trait Method Request where
-  type Attribute Method Request = HTTP.StdMethod
+type instance Attribute Method Request = HTTP.StdMethod
 
-instance TraitAbsence Method Request where
-  type Absence Method Request = MethodMismatch
+type instance Absence Method Request = MethodMismatch
 
 type instance Prerequisite Method ts Request = ()
 

--- a/webgear-core/src/WebGear/Core/Trait/Path.hs
+++ b/webgear-core/src/WebGear/Core/Trait/Path.hs
@@ -29,7 +29,7 @@ import Language.Haskell.TH.Quote (QuasiQuoter (..))
 import Language.Haskell.TH.Syntax (Exp (..), Lit (..), Q, TyLit (StrTyLit), Type (..), mkName)
 import WebGear.Core.Handler (Middleware, RouteMismatch, routeMismatch)
 import WebGear.Core.Request (Request)
-import WebGear.Core.Trait (Get, Prerequisite, Trait (..), TraitAbsence (..), probe)
+import WebGear.Core.Trait (Get, Prerequisite, Attribute, Absence, probe)
 import WebGear.Core.Trait.Method (method)
 import Prelude hiding (drop, filter, take)
 
@@ -38,11 +38,9 @@ import Prelude hiding (drop, filter, take)
 -}
 newtype Path = Path Text
 
-instance Trait Path Request where
-  type Attribute Path Request = ()
+type instance Attribute Path Request = ()
 
-instance TraitAbsence Path Request where
-  type Absence Path Request = ()
+type instance Absence Path Request = ()
 
 type instance Prerequisite Path ts Request = ()
 
@@ -56,22 +54,18 @@ data PathVar (tag :: Symbol) (val :: Data.Kind.Type) = PathVar
 data PathVarError = PathVarNotFound | PathVarParseError Text
   deriving stock (Eq, Show, Read)
 
-instance Trait (PathVar tag val) Request where
-  type Attribute (PathVar tag val) Request = val
+type instance Attribute (PathVar tag val) Request = val
 
-instance TraitAbsence (PathVar tag val) Request where
-  type Absence (PathVar tag val) Request = PathVarError
+type instance Absence (PathVar tag val) Request = PathVarError
 
 type instance Prerequisite (PathVar tag val) ts Request = ()
 
 -- | Trait to indicate that no more path components are present in the request
 data PathEnd = PathEnd
 
-instance Trait PathEnd Request where
-  type Attribute PathEnd Request = ()
+type instance Attribute PathEnd Request = ()
 
-instance TraitAbsence PathEnd Request where
-  type Absence PathEnd Request = ()
+type instance Absence PathEnd Request = ()
 
 type instance Prerequisite PathEnd ts Request = ()
 

--- a/webgear-core/src/WebGear/Core/Trait/Path.hs
+++ b/webgear-core/src/WebGear/Core/Trait/Path.hs
@@ -29,7 +29,7 @@ import Language.Haskell.TH.Quote (QuasiQuoter (..))
 import Language.Haskell.TH.Syntax (Exp (..), Lit (..), Q, TyLit (StrTyLit), Type (..), mkName)
 import WebGear.Core.Handler (Middleware, RouteMismatch, routeMismatch)
 import WebGear.Core.Request (Request)
-import WebGear.Core.Trait (Get, Prerequisite, Attribute, Absence, probe)
+import WebGear.Core.Trait (Absence, Attribute, Get, Prerequisite, probe)
 import WebGear.Core.Trait.Method (method)
 import Prelude hiding (drop, filter, take)
 
@@ -39,10 +39,8 @@ import Prelude hiding (drop, filter, take)
 newtype Path = Path Text
 
 type instance Attribute Path Request = ()
-
-type instance Absence Path Request = ()
-
-type instance Prerequisite Path ts Request = ()
+type instance Absence Path = ()
+type instance Prerequisite Path ts = ()
 
 {- | A path variable that is extracted and converted to a value of
  type @val@. The @tag@ is usually a type-level symbol (string) to
@@ -55,19 +53,15 @@ data PathVarError = PathVarNotFound | PathVarParseError Text
   deriving stock (Eq, Show, Read)
 
 type instance Attribute (PathVar tag val) Request = val
-
-type instance Absence (PathVar tag val) Request = PathVarError
-
-type instance Prerequisite (PathVar tag val) ts Request = ()
+type instance Absence (PathVar tag val) = PathVarError
+type instance Prerequisite (PathVar tag val) ts = ()
 
 -- | Trait to indicate that no more path components are present in the request
 data PathEnd = PathEnd
 
 type instance Attribute PathEnd Request = ()
-
-type instance Absence PathEnd Request = ()
-
-type instance Prerequisite PathEnd ts Request = ()
+type instance Absence PathEnd = ()
+type instance Prerequisite PathEnd ts = ()
 
 {- | A middleware that literally matches path @s@.
 
@@ -81,7 +75,7 @@ type instance Prerequisite PathEnd ts Request = ()
  > path "a/b/c" handler
 -}
 path ::
-  (Get h Path Request, ArrowChoice h, ArrowError RouteMismatch h) =>
+  (Get h Path, ArrowChoice h, ArrowError RouteMismatch h) =>
   Text ->
   Middleware h ts (Path : ts)
 path s nextHandler = probe (Path s) >>> routeMismatch ||| nextHandler
@@ -101,14 +95,14 @@ path s nextHandler = probe (Path s) >>> routeMismatch ||| nextHandler
 -}
 pathVar ::
   forall tag val h ts.
-  (Get h (PathVar tag val) Request, ArrowChoice h, ArrowError RouteMismatch h) =>
+  (Get h (PathVar tag val), ArrowChoice h, ArrowError RouteMismatch h) =>
   Middleware h ts (PathVar tag val : ts)
 pathVar nextHandler = probe PathVar >>> routeMismatch ||| nextHandler
 {-# INLINE pathVar #-}
 
 -- | A middleware that verifies that end of path is reached.
 pathEnd ::
-  (Get h PathEnd Request, ArrowChoice h, ArrowError RouteMismatch h) =>
+  (Get h PathEnd, ArrowChoice h, ArrowError RouteMismatch h) =>
   Middleware h ts (PathEnd : ts)
 pathEnd nextHandler = probe PathEnd >>> routeMismatch ||| nextHandler
 {-# INLINE pathEnd #-}

--- a/webgear-core/src/WebGear/Core/Trait/QueryParam.hs
+++ b/webgear-core/src/WebGear/Core/Trait/QueryParam.hs
@@ -43,7 +43,7 @@ import WebGear.Core.Handler (Middleware)
 import WebGear.Core.Modifiers (Existence (..), ParseStyle (..))
 import WebGear.Core.Request (Request)
 import WebGear.Core.Response (Response)
-import WebGear.Core.Trait (Get, Prerequisite, Trait (..), TraitAbsence (..), With, probe)
+import WebGear.Core.Trait (Get, Prerequisite, Attribute, Absence, With, probe)
 
 {- | Capture a query parameter with a specified @name@ and convert it to
  a value of type @val@. The type parameter @e@ denotes whether the
@@ -67,29 +67,21 @@ data ParamNotFound = ParamNotFound
 newtype ParamParseError = ParamParseError Text
   deriving stock (Read, Show, Eq)
 
-instance Trait (QueryParam Required Strict name val) Request where
-  type Attribute (QueryParam Required Strict name val) Request = val
+type instance Attribute (QueryParam Required Strict name val) Request = val
 
-instance TraitAbsence (QueryParam Required Strict name val) Request where
-  type Absence (QueryParam Required Strict name val) Request = Either ParamNotFound ParamParseError
+type instance Absence (QueryParam Required Strict name val) Request = Either ParamNotFound ParamParseError
 
-instance Trait (QueryParam Optional Strict name val) Request where
-  type Attribute (QueryParam Optional Strict name val) Request = Maybe val
+type instance Attribute (QueryParam Optional Strict name val) Request = Maybe val
 
-instance TraitAbsence (QueryParam Optional Strict name val) Request where
-  type Absence (QueryParam Optional Strict name val) Request = ParamParseError
+type instance Absence (QueryParam Optional Strict name val) Request = ParamParseError
 
-instance Trait (QueryParam Required Lenient name val) Request where
-  type Attribute (QueryParam Required Lenient name val) Request = Either Text val
+type instance Attribute (QueryParam Required Lenient name val) Request = Either Text val
 
-instance TraitAbsence (QueryParam Required Lenient name val) Request where
-  type Absence (QueryParam Required Lenient name val) Request = ParamNotFound
+type instance Absence (QueryParam Required Lenient name val) Request = ParamNotFound
 
-instance Trait (QueryParam Optional Lenient name val) Request where
-  type Attribute (QueryParam Optional Lenient name val) Request = Maybe (Either Text val)
+type instance Attribute (QueryParam Optional Lenient name val) Request = Maybe (Either Text val)
 
-instance TraitAbsence (QueryParam Optional Lenient name val) Request where
-  type Absence (QueryParam Optional Lenient name val) Request = Void
+type instance Absence (QueryParam Optional Lenient name val) Request = Void
 
 type instance Prerequisite (QueryParam e p name val) ts Request = ()
 

--- a/webgear-core/src/WebGear/Core/Trait/QueryParam.hs
+++ b/webgear-core/src/WebGear/Core/Trait/QueryParam.hs
@@ -43,7 +43,7 @@ import WebGear.Core.Handler (Middleware)
 import WebGear.Core.Modifiers (Existence (..), ParseStyle (..))
 import WebGear.Core.Request (Request)
 import WebGear.Core.Response (Response)
-import WebGear.Core.Trait (Get, Prerequisite, Attribute, Absence, With, probe)
+import WebGear.Core.Trait (Absence, Attribute, Get, Prerequisite, With, probe)
 
 {- | Capture a query parameter with a specified @name@ and convert it to
  a value of type @val@. The type parameter @e@ denotes whether the
@@ -68,27 +68,23 @@ newtype ParamParseError = ParamParseError Text
   deriving stock (Read, Show, Eq)
 
 type instance Attribute (QueryParam Required Strict name val) Request = val
-
-type instance Absence (QueryParam Required Strict name val) Request = Either ParamNotFound ParamParseError
+type instance Absence (QueryParam Required Strict name val) = Either ParamNotFound ParamParseError
 
 type instance Attribute (QueryParam Optional Strict name val) Request = Maybe val
-
-type instance Absence (QueryParam Optional Strict name val) Request = ParamParseError
+type instance Absence (QueryParam Optional Strict name val) = ParamParseError
 
 type instance Attribute (QueryParam Required Lenient name val) Request = Either Text val
-
-type instance Absence (QueryParam Required Lenient name val) Request = ParamNotFound
+type instance Absence (QueryParam Required Lenient name val) = ParamNotFound
 
 type instance Attribute (QueryParam Optional Lenient name val) Request = Maybe (Either Text val)
+type instance Absence (QueryParam Optional Lenient name val) = Void
 
-type instance Absence (QueryParam Optional Lenient name val) Request = Void
-
-type instance Prerequisite (QueryParam e p name val) ts Request = ()
+type instance Prerequisite (QueryParam e p name val) ts = ()
 
 queryParamHandler ::
   forall name val e p h ts.
-  (Get h (QueryParam e p name val) Request, ArrowChoice h) =>
-  h (Request `With` ts, Absence (QueryParam e p name val) Request) Response ->
+  (Get h (QueryParam e p name val), ArrowChoice h) =>
+  h (Request `With` ts, Absence (QueryParam e p name val)) Response ->
   Middleware h ts (QueryParam e p name val : ts)
 queryParamHandler errorHandler nextHandler = proc request -> do
   result <- probe QueryParam -< request
@@ -108,7 +104,7 @@ queryParamHandler errorHandler nextHandler = proc request -> do
 -}
 queryParam ::
   forall name val h ts.
-  (Get h (QueryParam Required Strict name val) Request, ArrowChoice h) =>
+  (Get h (QueryParam Required Strict name val), ArrowChoice h) =>
   h (Request `With` ts, Either ParamNotFound ParamParseError) Response ->
   Middleware h ts (QueryParam Required Strict name val : ts)
 queryParam = queryParamHandler
@@ -126,7 +122,7 @@ queryParam = queryParamHandler
 -}
 optionalQueryParam ::
   forall name val h ts.
-  (Get h (QueryParam Optional Strict name val) Request, ArrowChoice h) =>
+  (Get h (QueryParam Optional Strict name val), ArrowChoice h) =>
   h (Request `With` ts, ParamParseError) Response ->
   Middleware h ts (QueryParam Optional Strict name val : ts)
 optionalQueryParam = queryParamHandler
@@ -144,7 +140,7 @@ optionalQueryParam = queryParamHandler
 -}
 lenientQueryParam ::
   forall name val h ts.
-  (Get h (QueryParam Required Lenient name val) Request, ArrowChoice h) =>
+  (Get h (QueryParam Required Lenient name val), ArrowChoice h) =>
   h (Request `With` ts, ParamNotFound) Response ->
   Middleware h ts (QueryParam Required Lenient name val : ts)
 lenientQueryParam = queryParamHandler
@@ -162,7 +158,7 @@ lenientQueryParam = queryParamHandler
 -}
 optionalLenientQueryParam ::
   forall name val h ts.
-  (Get h (QueryParam Optional Lenient name val) Request, ArrowChoice h) =>
+  (Get h (QueryParam Optional Lenient name val), ArrowChoice h) =>
   Middleware h ts (QueryParam Optional Lenient name val : ts)
 optionalLenientQueryParam = queryParamHandler $ arr (absurd . snd)
 {-# INLINE optionalLenientQueryParam #-}

--- a/webgear-core/src/WebGear/Core/Trait/Status.hs
+++ b/webgear-core/src/WebGear/Core/Trait/Status.hs
@@ -62,238 +62,238 @@ newtype Status = Status HTTP.Status
 type instance Attribute Status Response = HTTP.Status
 
 -- | Generate a response with the specified status
-mkResponse :: (Set h Status Response) => HTTP.Status -> h () (Response `With` '[Status])
+mkResponse :: (Set h Status) => HTTP.Status -> h () (Response `With` '[Status])
 mkResponse status = proc () -> do
   let response = wzero $ Response status [] (ResponseBodyBuilder mempty)
   plant (Status status) -< (response, status)
 {-# INLINE mkResponse #-}
 
 -- | Continue 100 response
-continue100 :: (Set h Status Response) => h () (Response `With` '[Status])
+continue100 :: (Set h Status) => h () (Response `With` '[Status])
 continue100 = mkResponse HTTP.continue100
 {-# INLINE continue100 #-}
 
 -- | Switching Protocols 101 response
-switchingProtocols101 :: (Set h Status Response) => h () (Response `With` '[Status])
+switchingProtocols101 :: (Set h Status) => h () (Response `With` '[Status])
 switchingProtocols101 = mkResponse HTTP.switchingProtocols101
 {-# INLINE switchingProtocols101 #-}
 
 -- | OK 200 response
-ok200 :: (Set h Status Response) => h () (Response `With` '[Status])
+ok200 :: (Set h Status) => h () (Response `With` '[Status])
 ok200 = mkResponse HTTP.ok200
 {-# INLINE ok200 #-}
 
 -- | Created 201 response
-created201 :: (Set h Status Response) => h () (Response `With` '[Status])
+created201 :: (Set h Status) => h () (Response `With` '[Status])
 created201 = mkResponse HTTP.created201
 {-# INLINE created201 #-}
 
 -- | Accepted 202 response
-accepted202 :: (Set h Status Response) => h () (Response `With` '[Status])
+accepted202 :: (Set h Status) => h () (Response `With` '[Status])
 accepted202 = mkResponse HTTP.accepted202
 {-# INLINE accepted202 #-}
 
 -- | Non-Authoritative 203 response
-nonAuthoritative203 :: (Set h Status Response) => h () (Response `With` '[Status])
+nonAuthoritative203 :: (Set h Status) => h () (Response `With` '[Status])
 nonAuthoritative203 = mkResponse HTTP.nonAuthoritative203
 {-# INLINE nonAuthoritative203 #-}
 
 -- | No Content 204 response
-noContent204 :: (Set h Status Response) => h () (Response `With` '[Status])
+noContent204 :: (Set h Status) => h () (Response `With` '[Status])
 noContent204 = mkResponse HTTP.noContent204
 {-# INLINE noContent204 #-}
 
 -- | Reset Content 205 response
-resetContent205 :: (Set h Status Response) => h () (Response `With` '[Status])
+resetContent205 :: (Set h Status) => h () (Response `With` '[Status])
 resetContent205 = mkResponse HTTP.resetContent205
 {-# INLINE resetContent205 #-}
 
 -- | Partial Content 206 response
-partialContent206 :: (Set h Status Response) => h () (Response `With` '[Status])
+partialContent206 :: (Set h Status) => h () (Response `With` '[Status])
 partialContent206 = mkResponse HTTP.partialContent206
 {-# INLINE partialContent206 #-}
 
 -- | Multiple Choices 300 response
-multipleChoices300 :: (Set h Status Response) => h () (Response `With` '[Status])
+multipleChoices300 :: (Set h Status) => h () (Response `With` '[Status])
 multipleChoices300 = mkResponse HTTP.multipleChoices300
 {-# INLINE multipleChoices300 #-}
 
 -- | Moved Permanently 301 response
-movedPermanently301 :: (Set h Status Response) => h () (Response `With` '[Status])
+movedPermanently301 :: (Set h Status) => h () (Response `With` '[Status])
 movedPermanently301 = mkResponse HTTP.movedPermanently301
 {-# INLINE movedPermanently301 #-}
 
 -- | Found 302 response
-found302 :: (Set h Status Response) => h () (Response `With` '[Status])
+found302 :: (Set h Status) => h () (Response `With` '[Status])
 found302 = mkResponse HTTP.found302
 {-# INLINE found302 #-}
 
 -- | See Other 303 response
-seeOther303 :: (Set h Status Response) => h () (Response `With` '[Status])
+seeOther303 :: (Set h Status) => h () (Response `With` '[Status])
 seeOther303 = mkResponse HTTP.seeOther303
 {-# INLINE seeOther303 #-}
 
 -- | Not Modified 304 response
-notModified304 :: (Set h Status Response) => h () (Response `With` '[Status])
+notModified304 :: (Set h Status) => h () (Response `With` '[Status])
 notModified304 = mkResponse HTTP.notModified304
 {-# INLINE notModified304 #-}
 
 -- | Temporary Redirect 307 response
-temporaryRedirect307 :: (Set h Status Response) => h () (Response `With` '[Status])
+temporaryRedirect307 :: (Set h Status) => h () (Response `With` '[Status])
 temporaryRedirect307 = mkResponse HTTP.temporaryRedirect307
 {-# INLINE temporaryRedirect307 #-}
 
 -- | Permanent Redirect 308 response
-permanentRedirect308 :: (Set h Status Response) => h () (Response `With` '[Status])
+permanentRedirect308 :: (Set h Status) => h () (Response `With` '[Status])
 permanentRedirect308 = mkResponse HTTP.permanentRedirect308
 {-# INLINE permanentRedirect308 #-}
 
 -- | Bad Request 400 response
-badRequest400 :: (Set h Status Response) => h () (Response `With` '[Status])
+badRequest400 :: (Set h Status) => h () (Response `With` '[Status])
 badRequest400 = mkResponse HTTP.badRequest400
 {-# INLINE badRequest400 #-}
 
 -- | Unauthorized 401 response
-unauthorized401 :: (Set h Status Response) => h () (Response `With` '[Status])
+unauthorized401 :: (Set h Status) => h () (Response `With` '[Status])
 unauthorized401 = mkResponse HTTP.unauthorized401
 {-# INLINE unauthorized401 #-}
 
 -- | Payment Required 402 response
-paymentRequired402 :: (Set h Status Response) => h () (Response `With` '[Status])
+paymentRequired402 :: (Set h Status) => h () (Response `With` '[Status])
 paymentRequired402 = mkResponse HTTP.paymentRequired402
 {-# INLINE paymentRequired402 #-}
 
 -- | Forbidden 403 response
-forbidden403 :: (Set h Status Response) => h () (Response `With` '[Status])
+forbidden403 :: (Set h Status) => h () (Response `With` '[Status])
 forbidden403 = mkResponse HTTP.forbidden403
 {-# INLINE forbidden403 #-}
 
 -- | Not Found 404 response
-notFound404 :: (Set h Status Response) => h () (Response `With` '[Status])
+notFound404 :: (Set h Status) => h () (Response `With` '[Status])
 notFound404 = mkResponse HTTP.notFound404
 {-# INLINE notFound404 #-}
 
 -- | Method Not Allowed 405 response
-methodNotAllowed405 :: (Set h Status Response) => h () (Response `With` '[Status])
+methodNotAllowed405 :: (Set h Status) => h () (Response `With` '[Status])
 methodNotAllowed405 = mkResponse HTTP.methodNotAllowed405
 {-# INLINE methodNotAllowed405 #-}
 
 -- | Not Acceptable 406 response
-notAcceptable406 :: (Set h Status Response) => h () (Response `With` '[Status])
+notAcceptable406 :: (Set h Status) => h () (Response `With` '[Status])
 notAcceptable406 = mkResponse HTTP.notAcceptable406
 {-# INLINE notAcceptable406 #-}
 
 -- | Proxy Authentication Required 407 response
-proxyAuthenticationRequired407 :: (Set h Status Response) => h () (Response `With` '[Status])
+proxyAuthenticationRequired407 :: (Set h Status) => h () (Response `With` '[Status])
 proxyAuthenticationRequired407 = mkResponse HTTP.proxyAuthenticationRequired407
 {-# INLINE proxyAuthenticationRequired407 #-}
 
 -- | Request Timeout 408 response
-requestTimeout408 :: (Set h Status Response) => h () (Response `With` '[Status])
+requestTimeout408 :: (Set h Status) => h () (Response `With` '[Status])
 requestTimeout408 = mkResponse HTTP.requestTimeout408
 {-# INLINE requestTimeout408 #-}
 
 -- | Conflict 409 response
-conflict409 :: (Set h Status Response) => h () (Response `With` '[Status])
+conflict409 :: (Set h Status) => h () (Response `With` '[Status])
 conflict409 = mkResponse HTTP.conflict409
 {-# INLINE conflict409 #-}
 
 -- | Gone 410 response
-gone410 :: (Set h Status Response) => h () (Response `With` '[Status])
+gone410 :: (Set h Status) => h () (Response `With` '[Status])
 gone410 = mkResponse HTTP.gone410
 {-# INLINE gone410 #-}
 
 -- | Length Required 411 response
-lengthRequired411 :: (Set h Status Response) => h () (Response `With` '[Status])
+lengthRequired411 :: (Set h Status) => h () (Response `With` '[Status])
 lengthRequired411 = mkResponse HTTP.lengthRequired411
 {-# INLINE lengthRequired411 #-}
 
 -- | Precondition Failed 412 response
-preconditionFailed412 :: (Set h Status Response) => h () (Response `With` '[Status])
+preconditionFailed412 :: (Set h Status) => h () (Response `With` '[Status])
 preconditionFailed412 = mkResponse HTTP.preconditionFailed412
 {-# INLINE preconditionFailed412 #-}
 
 -- | Request Entity Too Large 413 response
-requestEntityTooLarge413 :: (Set h Status Response) => h () (Response `With` '[Status])
+requestEntityTooLarge413 :: (Set h Status) => h () (Response `With` '[Status])
 requestEntityTooLarge413 = mkResponse HTTP.requestEntityTooLarge413
 {-# INLINE requestEntityTooLarge413 #-}
 
 -- | Request URI Too Long 414 response
-requestURITooLong414 :: (Set h Status Response) => h () (Response `With` '[Status])
+requestURITooLong414 :: (Set h Status) => h () (Response `With` '[Status])
 requestURITooLong414 = mkResponse HTTP.requestURITooLong414
 {-# INLINE requestURITooLong414 #-}
 
 -- | Unsupported Media Type 415 response
-unsupportedMediaType415 :: (Set h Status Response) => h () (Response `With` '[Status])
+unsupportedMediaType415 :: (Set h Status) => h () (Response `With` '[Status])
 unsupportedMediaType415 = mkResponse HTTP.unsupportedMediaType415
 {-# INLINE unsupportedMediaType415 #-}
 
 -- | Requested Range Not Satisfiable 416 response
-requestedRangeNotSatisfiable416 :: (Set h Status Response) => h () (Response `With` '[Status])
+requestedRangeNotSatisfiable416 :: (Set h Status) => h () (Response `With` '[Status])
 requestedRangeNotSatisfiable416 = mkResponse HTTP.requestedRangeNotSatisfiable416
 {-# INLINE requestedRangeNotSatisfiable416 #-}
 
 -- | Expectation Failed 417 response
-expectationFailed417 :: (Set h Status Response) => h () (Response `With` '[Status])
+expectationFailed417 :: (Set h Status) => h () (Response `With` '[Status])
 expectationFailed417 = mkResponse HTTP.expectationFailed417
 {-# INLINE expectationFailed417 #-}
 
 -- | I'm A Teapot 418 response
-imATeapot418 :: (Set h Status Response) => h () (Response `With` '[Status])
+imATeapot418 :: (Set h Status) => h () (Response `With` '[Status])
 imATeapot418 = mkResponse HTTP.imATeapot418
 {-# INLINE imATeapot418 #-}
 
 -- | Unprocessable Entity 422 response
-unprocessableEntity422 :: (Set h Status Response) => h () (Response `With` '[Status])
+unprocessableEntity422 :: (Set h Status) => h () (Response `With` '[Status])
 unprocessableEntity422 = mkResponse HTTP.unprocessableEntity422
 {-# INLINE unprocessableEntity422 #-}
 
 -- | Precondition Required 428 response
-preconditionRequired428 :: (Set h Status Response) => h () (Response `With` '[Status])
+preconditionRequired428 :: (Set h Status) => h () (Response `With` '[Status])
 preconditionRequired428 = mkResponse HTTP.preconditionRequired428
 {-# INLINE preconditionRequired428 #-}
 
 -- | Too Many Requests 429 response
-tooManyRequests429 :: (Set h Status Response) => h () (Response `With` '[Status])
+tooManyRequests429 :: (Set h Status) => h () (Response `With` '[Status])
 tooManyRequests429 = mkResponse HTTP.tooManyRequests429
 {-# INLINE tooManyRequests429 #-}
 
 -- | Request Header Fields Too Large 431 response
-requestHeaderFieldsTooLarge431 :: (Set h Status Response) => h () (Response `With` '[Status])
+requestHeaderFieldsTooLarge431 :: (Set h Status) => h () (Response `With` '[Status])
 requestHeaderFieldsTooLarge431 = mkResponse HTTP.requestHeaderFieldsTooLarge431
 {-# INLINE requestHeaderFieldsTooLarge431 #-}
 
 -- | Internal Server Error 500 response
-internalServerError500 :: (Set h Status Response) => h () (Response `With` '[Status])
+internalServerError500 :: (Set h Status) => h () (Response `With` '[Status])
 internalServerError500 = mkResponse HTTP.internalServerError500
 {-# INLINE internalServerError500 #-}
 
 -- | Not Implemented 501 response
-notImplemented501 :: (Set h Status Response) => h () (Response `With` '[Status])
+notImplemented501 :: (Set h Status) => h () (Response `With` '[Status])
 notImplemented501 = mkResponse HTTP.notImplemented501
 {-# INLINE notImplemented501 #-}
 
 -- | Bad Gateway 502 response
-badGateway502 :: (Set h Status Response) => h () (Response `With` '[Status])
+badGateway502 :: (Set h Status) => h () (Response `With` '[Status])
 badGateway502 = mkResponse HTTP.badGateway502
 {-# INLINE badGateway502 #-}
 
 -- | Service Unavailable 503 response
-serviceUnavailable503 :: (Set h Status Response) => h () (Response `With` '[Status])
+serviceUnavailable503 :: (Set h Status) => h () (Response `With` '[Status])
 serviceUnavailable503 = mkResponse HTTP.serviceUnavailable503
 {-# INLINE serviceUnavailable503 #-}
 
 -- | Gateway Timeout 504 response
-gatewayTimeout504 :: (Set h Status Response) => h () (Response `With` '[Status])
+gatewayTimeout504 :: (Set h Status) => h () (Response `With` '[Status])
 gatewayTimeout504 = mkResponse HTTP.gatewayTimeout504
 {-# INLINE gatewayTimeout504 #-}
 
 -- | HTTP Version Not Supported 505 response
-httpVersionNotSupported505 :: (Set h Status Response) => h () (Response `With` '[Status])
+httpVersionNotSupported505 :: (Set h Status) => h () (Response `With` '[Status])
 httpVersionNotSupported505 = mkResponse HTTP.httpVersionNotSupported505
 {-# INLINE httpVersionNotSupported505 #-}
 
 -- | Network Authentication Required 511 response
-networkAuthenticationRequired511 :: (Set h Status Response) => h () (Response `With` '[Status])
+networkAuthenticationRequired511 :: (Set h Status) => h () (Response `With` '[Status])
 networkAuthenticationRequired511 = mkResponse HTTP.networkAuthenticationRequired511
 {-# INLINE networkAuthenticationRequired511 #-}

--- a/webgear-core/src/WebGear/Core/Trait/Status.hs
+++ b/webgear-core/src/WebGear/Core/Trait/Status.hs
@@ -54,13 +54,12 @@ module WebGear.Core.Trait.Status (
 
 import qualified Network.HTTP.Types as HTTP
 import WebGear.Core.Response (Response (..), ResponseBody (ResponseBodyBuilder))
-import WebGear.Core.Trait (Set, Trait (..), With, plant, wzero)
+import WebGear.Core.Trait (Attribute, Set, With, plant, wzero)
 
 -- | HTTP response status
 newtype Status = Status HTTP.Status
 
-instance Trait Status Response where
-  type Attribute Status Response = HTTP.Status
+type instance Attribute Status Response = HTTP.Status
 
 -- | Generate a response with the specified status
 mkResponse :: (Set h Status Response) => HTTP.Status -> h () (Response `With` '[Status])

--- a/webgear-core/src/WebGear/Core/Traits.hs
+++ b/webgear-core/src/WebGear/Core/Traits.hs
@@ -17,8 +17,6 @@ import qualified Data.Text as Text
 import qualified Data.Text.Lazy as LText
 import WebGear.Core.Handler (Handler)
 import WebGear.Core.MIMETypes (PlainText)
-import WebGear.Core.Request (Request)
-import WebGear.Core.Response (Response)
 import WebGear.Core.Trait (Gets, Sets)
 import WebGear.Core.Trait.Auth.Basic
 import WebGear.Core.Trait.Auth.Common
@@ -40,13 +38,13 @@ import WebGear.Core.Trait.Status
 -}
 type StdHandler h m =
   ( Handler h m
-  , Gets h [Method, Path, PathEnd] Request
+  , Gets h [Method, Path, PathEnd]
   , Sets
       h
       '[ Status
        , Body PlainText String
        , Body PlainText Text.Text
        , Body PlainText LText.Text
+       , RequiredResponseHeader "Content-Type" Text.Text
        ]
-      Response
   )

--- a/webgear-example-realworld/src/API/Article.hs
+++ b/webgear-example-realworld/src/API/Article.hs
@@ -19,7 +19,7 @@ import qualified Database.Sqlite as DB
 import qualified Model.Article as Model
 import Model.Entities
 import qualified Network.HTTP.Types as HTTP
-import Relude hiding ((.))
+import Relude hiding (Set, (.))
 import WebGear.Server hiding (length)
 
 type CreateArticleRequest = Wrapped "article" Model.CreateArticlePayload
@@ -27,8 +27,8 @@ type ArticleResponse = Wrapped "article" Model.ArticleRecord
 
 create ::
   ( StdHandler h App
-  , Gets h [AuthHeader, RequiredAuth, JSONBody CreateArticleRequest] Request
-  , Sets h (JSONBodyOrError ArticleResponse) Response
+  , Gets h [AuthHeader, RequiredAuth, JSONBody CreateArticleRequest]
+  , Sets h (JSONBodyOrError ArticleResponse)
   ) =>
   JWT.JWK ->
   RequestHandler h ts
@@ -50,7 +50,7 @@ create jwk =
 
 handleDBError ::
   ( StdHandler h App
-  , Sets h [RequiredResponseHeader "Content-Type" Text, JSONBody ErrorResponse] Response
+  , Set h (JSONBody ErrorResponse)
   ) =>
   h DB.SqliteException Response
 handleDBError = proc e ->
@@ -62,8 +62,8 @@ handleDBError = proc e ->
 
 getBySlug ::
   ( StdHandler h App
-  , Gets h [AuthHeader, OptionalAuth] Request
-  , Sets h [RequiredResponseHeader "Content-Type" Text, JSONBody ArticleResponse] Response
+  , Gets h [AuthHeader, OptionalAuth]
+  , Set h (JSONBody ArticleResponse)
   , HasTrait PathVarSlug ts
   ) =>
   JWT.JWK ->
@@ -92,8 +92,8 @@ update ::
   forall h ts.
   ( HasTrait PathVarSlug ts
   , StdHandler h App
-  , Gets h [AuthHeader, RequiredAuth, JSONBody UpdateArticleRequest] Request
-  , Sets h (JSONBodyOrError ArticleResponse) Response
+  , Gets h [AuthHeader, RequiredAuth, JSONBody UpdateArticleRequest]
+  , Sets h (JSONBodyOrError ArticleResponse)
   ) =>
   JWT.JWK ->
   RequestHandler h ts
@@ -134,8 +134,8 @@ update jwk =
 delete ::
   ( HasTrait PathVarSlug ts
   , StdHandler h App
-  , Gets h [AuthHeader, RequiredAuth] Request
-  , Sets h [RequiredResponseHeader "Content-Type" Text, JSONBody ErrorResponse] Response
+  , Gets h [AuthHeader, RequiredAuth]
+  , Set h (JSONBody ErrorResponse)
   ) =>
   JWT.JWK ->
   RequestHandler h ts
@@ -163,8 +163,8 @@ data ArticleListResponse = ArticleListResponse
 param ::
   forall name val h ts.
   ( StdHandler h App
-  , Get h (OptionalQueryParam name val) Request
-  , Sets h [RequiredResponseHeader "Content-Type" Text, JSONBody ErrorResponse] Response
+  , Get h (OptionalQueryParam name val)
+  , Set h (JSONBody ErrorResponse)
   ) =>
   Description ->
   Middleware h ts (OptionalQueryParam name val : ts)
@@ -182,8 +182,7 @@ list ::
       , OptionalQueryParam "limit" Model.Limit
       , OptionalQueryParam "offset" Model.Offset
       ]
-      Request
-  , Sets h (JSONBodyOrError ArticleListResponse) Response
+  , Sets h (JSONBodyOrError ArticleListResponse)
   ) =>
   JWT.JWK ->
   RequestHandler h ts
@@ -221,8 +220,7 @@ feed ::
       , OptionalQueryParam "limit" Model.Limit
       , OptionalQueryParam "offset" Model.Offset
       ]
-      Request
-  , Sets h (JSONBodyOrError ArticleListResponse) Response
+  , Sets h (JSONBodyOrError ArticleListResponse)
   ) =>
   JWT.JWK ->
   RequestHandler h ts
@@ -248,8 +246,8 @@ feed jwk =
 favorite ::
   ( HasTrait PathVarSlug ts
   , StdHandler h App
-  , Gets h [AuthHeader, RequiredAuth] Request
-  , Sets h (JSONBodyOrError ArticleResponse) Response
+  , Gets h [AuthHeader, RequiredAuth]
+  , Sets h (JSONBodyOrError ArticleResponse)
   ) =>
   JWT.JWK ->
   RequestHandler h ts
@@ -274,8 +272,8 @@ favorite jwk =
 unfavorite ::
   ( HasTrait PathVarSlug ts
   , StdHandler h App
-  , Gets h [AuthHeader, RequiredAuth] Request
-  , Sets h (JSONBodyOrError ArticleResponse) Response
+  , Gets h [AuthHeader, RequiredAuth]
+  , Sets h (JSONBodyOrError ArticleResponse)
   ) =>
   JWT.JWK ->
   RequestHandler h ts

--- a/webgear-example-realworld/src/API/Comment.hs
+++ b/webgear-example-realworld/src/API/Comment.hs
@@ -20,8 +20,8 @@ type PathVarCommentId = PathVar "commentId" Int64
 
 create ::
   ( StdHandler h App
-  , Gets h [AuthHeader, RequiredAuth, JSONBody CreateCommentRequest] Request
-  , Sets h (JSONBodyOrError CommentResponse) Response
+  , Gets h [AuthHeader, RequiredAuth, JSONBody CreateCommentRequest]
+  , Sets h (JSONBodyOrError CommentResponse)
   , HasTrait PathVarSlug ts
   ) =>
   JWT.JWK ->
@@ -48,8 +48,8 @@ type CommentListResponse = Wrapped "comments" [Model.CommentRecord]
 
 list ::
   ( StdHandler h App
-  , Gets h [AuthHeader, OptionalAuth] Request
-  , Sets h (JSONBodyOrError CommentListResponse) Response
+  , Gets h [AuthHeader, OptionalAuth]
+  , Sets h (JSONBodyOrError CommentListResponse)
   , HasTrait PathVarSlug ts
   ) =>
   JWT.JWK ->
@@ -70,8 +70,8 @@ list jwk =
 
 delete ::
   ( StdHandler h App
-  , Gets h [AuthHeader, RequiredAuth] Request
-  , Sets h [RequiredResponseHeader "Content-Type" Text, JSONBody ErrorResponse] Response
+  , Gets h [AuthHeader, RequiredAuth]
+  , Set h (JSONBody ErrorResponse)
   , HaveTraits [PathVarSlug, PathVarCommentId] ts
   ) =>
   JWT.JWK ->

--- a/webgear-example-realworld/src/API/Common.hs
+++ b/webgear-example-realworld/src/API/Common.hs
@@ -94,8 +94,8 @@ type OptionalAuth = JWTAuth' Optional "token" App () (Key User)
 
 requiredTokenAuth ::
   ( StdHandler h App
-  , Gets h [RequiredAuth, AuthHeader] Request
-  , Sets h [RequiredResponseHeader "Content-Type" Text, JSONBody ErrorResponse] Response
+  , Gets h [RequiredAuth, AuthHeader]
+  , Sets h [RequiredResponseHeader "Content-Type" Text, JSONBody ErrorResponse]
   ) =>
   JWT.JWK ->
   Middleware h ts (RequiredAuth : AuthHeader : ts)
@@ -117,7 +117,7 @@ requiredTokenAuth jwk =
 
 optionalTokenAuth ::
   ( StdHandler h App
-  , Gets h [OptionalAuth, AuthHeader] Request
+  , Gets h [OptionalAuth, AuthHeader]
   ) =>
   JWT.JWK ->
   Middleware h ts (OptionalAuth : AuthHeader : ts)
@@ -127,7 +127,7 @@ optionalTokenAuth jwk =
 
 tokenAuth ::
   ( Handler h App
-  , Get h AuthHeader Request
+  , Get h AuthHeader
   ) =>
   JWT.JWK ->
   (JWTAuth' x "token" App () (Key User) -> Middleware h ts (r : ts)) ->
@@ -179,7 +179,7 @@ type PathVarSlug = PathVar "slug" Text
 
 respondJsonA ::
   ( StdHandler h m
-  , Sets h [ResponseHeader Required "Content-Type" Text, JSONBody body] Response
+  , Sets h [ResponseHeader Required "Content-Type" Text, JSONBody body]
   ) =>
   HTTP.Status ->
   h body Response
@@ -187,15 +187,13 @@ respondJsonA status = respondA status JSON
 
 jsonRequestBody ::
   forall t ts h m.
-  (StdHandler h m, Get h (JSONBody t) Request) =>
+  (StdHandler h m, Get h (JSONBody t)) =>
   h (Request `With` ts, Text) Response ->
   Middleware h ts (JSONBody t : ts)
 jsonRequestBody = requestBody JSON
 
 badRequestBody ::
-  ( StdHandler h m
-  , Sets h [RequiredResponseHeader "Content-Type" Text, JSONBody ErrorResponse] Response
-  ) =>
+  (StdHandler h m, Set h (JSONBody ErrorResponse)) =>
   h a Response
 badRequestBody = proc _ ->
   setDescription "Invalid request body"
@@ -204,9 +202,7 @@ badRequestBody = proc _ ->
       "Could not parse body" :: ErrorResponse
 
 badRequestParam ::
-  ( StdHandler h m
-  , Sets h [RequiredResponseHeader "Content-Type" Text, JSONBody ErrorResponse] Response
-  ) =>
+  (StdHandler h m, Set h (JSONBody ErrorResponse)) =>
   h (Request `With` ts, ParamParseError) Response
 badRequestParam = proc (_, e) ->
   setDescription "Invalid query parameter"
@@ -233,4 +229,4 @@ instance IsString ErrorRecord where
 
 type ErrorResponse = Wrapped "errors" ErrorRecord
 
-type JSONBodyOrError a = [RequiredResponseHeader "Content-Type" Text, JSONBody a, JSONBody ErrorResponse]
+type JSONBodyOrError a = [JSONBody a, JSONBody ErrorResponse]

--- a/webgear-example-realworld/src/API/Profile.hs
+++ b/webgear-example-realworld/src/API/Profile.hs
@@ -9,7 +9,7 @@ import Control.Category ((.))
 import qualified Crypto.JWT as JWT
 import qualified Model.Profile as Model
 import qualified Network.HTTP.Types as HTTP
-import Relude hiding ((.))
+import Relude hiding (Set, (.))
 import WebGear.Server
 
 type ProfileResponse = Wrapped "profile" Model.Profile
@@ -19,8 +19,8 @@ type PathVarUsername = PathVar "username" Text
 getByName ::
   ( HasTrait PathVarUsername ts
   , StdHandler h App
-  , Gets h [AuthHeader, OptionalAuth] Request
-  , Sets h [RequiredResponseHeader "Content-Type" Text, JSONBody ProfileResponse] Response
+  , Gets h [AuthHeader, OptionalAuth]
+  , Set h (JSONBody ProfileResponse)
   ) =>
   JWT.JWK ->
   RequestHandler h ts
@@ -41,8 +41,8 @@ getByName jwk =
 follow ::
   ( HasTrait PathVarUsername ts
   , StdHandler h App
-  , Gets h [AuthHeader, RequiredAuth] Request
-  , Sets h (JSONBodyOrError ProfileResponse) Response
+  , Gets h [AuthHeader, RequiredAuth]
+  , Sets h (JSONBodyOrError ProfileResponse)
   ) =>
   JWT.JWK ->
   RequestHandler h ts
@@ -63,8 +63,8 @@ follow jwk =
 unfollow ::
   ( HasTrait PathVarUsername ts
   , StdHandler h App
-  , Gets h [AuthHeader, RequiredAuth] Request
-  , Sets h (JSONBodyOrError ProfileResponse) Response
+  , Gets h [AuthHeader, RequiredAuth]
+  , Sets h (JSONBodyOrError ProfileResponse)
   ) =>
   JWT.JWK ->
   RequestHandler h ts

--- a/webgear-example-realworld/src/API/Tag.hs
+++ b/webgear-example-realworld/src/API/Tag.hs
@@ -6,14 +6,14 @@ import API.Common
 import Control.Category ((.))
 import qualified Model.Tag as Model
 import qualified Network.HTTP.Types as HTTP
-import Relude hiding ((.))
+import Relude hiding (Set, (.))
 import WebGear.Server
 
 type TagsResponse = Wrapped "tags" [Text]
 
 list ::
   ( StdHandler h App
-  , Sets h [RequiredResponseHeader "Content-Type" Text, JSONBody TagsResponse] Response
+  , Set h (JSONBody TagsResponse)
   ) =>
   RequestHandler h ts
 list =

--- a/webgear-example-realworld/src/API/User.hs
+++ b/webgear-example-realworld/src/API/User.hs
@@ -12,7 +12,7 @@ import qualified Crypto.JWT as JWT
 import qualified Database.Sqlite as DB
 import qualified Model.User as Model
 import qualified Network.HTTP.Types as HTTP
-import Relude hiding ((.))
+import Relude hiding (Set, (.))
 import WebGear.Server
 
 type CreateUserRequest = Wrapped "user" Model.CreateUserPayload
@@ -20,8 +20,8 @@ type UserResponse = Wrapped "user" Model.UserRecord
 
 create ::
   ( StdHandler h App
-  , Get h (JSONBody CreateUserRequest) Request
-  , Sets h (JSONBodyOrError UserResponse) Response
+  , Get h (JSONBody CreateUserRequest)
+  , Sets h (JSONBodyOrError UserResponse)
   ) =>
   JWT.JWK ->
   RequestHandler h ts
@@ -43,9 +43,7 @@ create jwk =
       try $ runDBAction $ Model.create jwk (unwrap userPayload)
 
 handleDBError ::
-  ( StdHandler h App
-  , Sets h [RequiredResponseHeader "Content-Type" Text, JSONBody ErrorResponse] Response
-  ) =>
+  (StdHandler h App, Set h (JSONBody ErrorResponse)) =>
   h DB.SqliteException Response
 handleDBError = proc e ->
   if DB.seError e == DB.ErrorConstraint
@@ -62,8 +60,8 @@ type LoginUserRequest = Wrapped "user" Model.LoginUserPayload
 
 login ::
   ( StdHandler h App
-  , Get h (JSONBody LoginUserRequest) Request
-  , Sets h (JSONBodyOrError UserResponse) Response
+  , Get h (JSONBody LoginUserRequest)
+  , Sets h (JSONBodyOrError UserResponse)
   ) =>
   JWT.JWK ->
   RequestHandler h ts
@@ -92,8 +90,8 @@ login jwk =
 
 current ::
   ( StdHandler h App
-  , Gets h [AuthHeader, RequiredAuth] Request
-  , Sets h (JSONBodyOrError UserResponse) Response
+  , Gets h [AuthHeader, RequiredAuth]
+  , Sets h (JSONBodyOrError UserResponse)
   ) =>
   JWT.JWK ->
   RequestHandler h ts
@@ -120,8 +118,8 @@ type UpdateUserRequest = Wrapped "user" Model.UpdateUserPayload
 
 update ::
   ( StdHandler h App
-  , Gets h [AuthHeader, RequiredAuth, JSONBody UpdateUserRequest] Request
-  , Sets h (JSONBodyOrError UserResponse) Response
+  , Gets h [AuthHeader, RequiredAuth, JSONBody UpdateUserRequest]
+  , Sets h (JSONBodyOrError UserResponse)
   ) =>
   JWT.JWK ->
   RequestHandler h ts

--- a/webgear-example-realworld/src/Main.hs
+++ b/webgear-example-realworld/src/Main.hs
@@ -1,4 +1,4 @@
-{-# OPTIONS_GHC -Wno-missing-signatures #-}
+{-# LANGUAGE NoMonomorphismRestriction #-}
 
 module Main where
 
@@ -28,35 +28,37 @@ import WebGear.Swagger.UI (swaggerUI)
 -- A medium.com clone app specified by https://github.com/gothinkster/realworld
 --------------------------------------------------------------------------------
 
-appRoutes jwk =
-  [route| POST    /api/users/login                                 |] (User.login jwk)
-    <+> [route|       POST    /api/users                                       |] (User.create jwk)
-    <+> [route| GET     /api/user                                        |] (User.current jwk)
-    <+> [route| PUT     /api/user                                        |] (User.update jwk)
-    <+> [route| GET     /api/profiles/username:Text                      |] (Profile.getByName jwk)
-    <+> [route| POST    /api/profiles/username:Text/follow               |] (Profile.follow jwk)
-    <+> [route| DELETE  /api/profiles/username:Text/follow               |] (Profile.unfollow jwk)
-    <+> [route| POST    /api/articles                                    |] (Article.create jwk)
-    <+> [route| GET     /api/articles                                    |] (Article.list jwk)
-    <+> [route| GET     /api/articles/feed                               |] (Article.feed jwk)
-    <+> [route| GET     /api/articles/slug:Text                          |] (Article.getBySlug jwk)
-    <+> [route| PUT     /api/articles/slug:Text                          |] (Article.update jwk)
-    <+> [route| DELETE  /api/articles/slug:Text                          |] (Article.delete jwk)
-    <+> [route| POST    /api/articles/slug:Text/favorite                 |] (Article.favorite jwk)
-    <+> [route| DELETE  /api/articles/slug:Text/favorite                 |] (Article.unfavorite jwk)
-    <+> [route| POST    /api/articles/slug:Text/comments                 |] (Comment.create jwk)
-    <+> [route| GET     /api/articles/slug:Text/comments                 |] (Comment.list jwk)
-    <+> [route| DELETE  /api/articles/slug:Text/comments/commentId:Int64 |] (Comment.delete jwk)
-    <+> [route| GET     /api/tags                                        |] Tag.list
-
 application :: Pool SqlBackend -> JWT.JWK -> Wai.Application
 application pool jwk = toApplication $ transform appToIO allRoutes
   where
+    allRoutes :: RequestHandler (ServerHandler App) '[]
     allRoutes =
-      appRoutes jwk
-        <+> [match| /openapi |] (swaggerUI $ toOpenApi @App $ appRoutes jwk)
+      appRoutes
+        <+> [match| /openapi |] (swaggerUI $ toOpenApi @App $ appRoutes)
         <+> uiRoutes
 
+    appRoutes =
+      [route| POST    /api/users/login                                 |] (User.login jwk)
+        <+> [route| POST    /api/users                                       |] (User.create jwk)
+        <+> [route| GET     /api/user                                        |] (User.current jwk)
+        <+> [route| PUT     /api/user                                        |] (User.update jwk)
+        <+> [route| GET     /api/profiles/username:Text                      |] (Profile.getByName jwk)
+        <+> [route| POST    /api/profiles/username:Text/follow               |] (Profile.follow jwk)
+        <+> [route| DELETE  /api/profiles/username:Text/follow               |] (Profile.unfollow jwk)
+        <+> [route| POST    /api/articles                                    |] (Article.create jwk)
+        <+> [route| GET     /api/articles                                    |] (Article.list jwk)
+        <+> [route| GET     /api/articles/feed                               |] (Article.feed jwk)
+        <+> [route| GET     /api/articles/slug:Text                          |] (Article.getBySlug jwk)
+        <+> [route| PUT     /api/articles/slug:Text                          |] (Article.update jwk)
+        <+> [route| DELETE  /api/articles/slug:Text                          |] (Article.delete jwk)
+        <+> [route| POST    /api/articles/slug:Text/favorite                 |] (Article.favorite jwk)
+        <+> [route| DELETE  /api/articles/slug:Text/favorite                 |] (Article.unfavorite jwk)
+        <+> [route| POST    /api/articles/slug:Text/comments                 |] (Comment.create jwk)
+        <+> [route| GET     /api/articles/slug:Text/comments                 |] (Comment.list jwk)
+        <+> [route| DELETE  /api/articles/slug:Text/comments/commentId:Int64 |] (Comment.delete jwk)
+        <+> [route| GET     /api/tags                                        |] Tag.list
+
+    uiRoutes :: RequestHandler (ServerHandler App) '[]
     uiRoutes = method GET UI.assets
 
     appToIO :: App a -> IO a

--- a/webgear-example-users/src/Main.hs
+++ b/webgear-example-users/src/Main.hs
@@ -110,7 +110,7 @@ userRoutes =
 publicRoutes ::
   ( HasTrait IntUserId ts
   , StdHandler h App
-  , Sets h '[RequiredResponseHeader "Content-Type" Text, Body JSON User] Response
+  , Set h (Body JSON User)
   ) =>
   RequestHandler h ts
 publicRoutes = getUser
@@ -120,8 +120,8 @@ protectedRoutes ::
   forall h ts.
   ( HasTrait IntUserId ts
   , StdHandler h App
-  , Gets h '[AuthorizationHeader "Basic", BasicAuth App () Credentials, Body JSON User] Request
-  , Sets h '[RequiredResponseHeader "Content-Type" Text, Body JSON User] Response
+  , Gets h '[AuthorizationHeader "Basic", BasicAuth App () Credentials, Body JSON User]
+  , Set h (Body JSON User)
   ) =>
   RequestHandler h ts
 protectedRoutes =
@@ -141,7 +141,7 @@ getUser ::
   forall h ts.
   ( HasTrait IntUserId ts
   , StdHandler h App
-  , Sets h '[RequiredResponseHeader "Content-Type" Text, Body JSON User] Response
+  , Set h (Body JSON User)
   ) =>
   RequestHandler h ts
 getUser = method HTTP.GET $
@@ -161,8 +161,8 @@ putUser ::
   forall h ts.
   ( HaveTraits [Auth, IntUserId] ts
   , StdHandler h App
-  , Get h (Body JSON User) Request
-  , Sets h '[RequiredResponseHeader "Content-Type" Text, Body JSON User] Response
+  , Get h (Body JSON User)
+  , Set h (Body JSON User)
   ) =>
   RequestHandler h ts
 putUser = method HTTP.PUT $

--- a/webgear-openapi/CHANGELOG.md
+++ b/webgear-openapi/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Changed
+- Simplify core API (breaking change) (#47)
 - Reimplement Swagger/OpenAPI internals (#45)
 
 ## [1.2.0] - 2024-03-18

--- a/webgear-openapi/src/WebGear/OpenApi/Trait/Auth/Basic.hs
+++ b/webgear-openapi/src/WebGear/OpenApi/Trait/Auth/Basic.hs
@@ -8,16 +8,16 @@ import Data.Proxy (Proxy (..))
 import Data.String (fromString)
 import GHC.TypeLits (KnownSymbol, symbolVal)
 import WebGear.Core.Request (Request)
-import WebGear.Core.Trait (Attribute, Absence, Get (..), With)
+import WebGear.Core.Trait (Absence, Attribute, Get (..), With)
 import WebGear.Core.Trait.Auth.Basic (BasicAuth' (..))
 import WebGear.OpenApi.Handler (OpenApiHandler (..))
 import WebGear.OpenApi.Trait.Auth (addSecurityScheme)
 
-instance (KnownSymbol scheme) => Get (OpenApiHandler m) (BasicAuth' x scheme m e a) Request where
+instance (KnownSymbol scheme) => Get (OpenApiHandler m) (BasicAuth' x scheme m e a) where
   {-# INLINE getTrait #-}
   getTrait ::
     BasicAuth' x scheme m e a ->
-    OpenApiHandler m (Request `With` ts) (Either (Absence (BasicAuth' x scheme m e a) Request) (Attribute (BasicAuth' x scheme m e a) Request))
+    OpenApiHandler m (Request `With` ts) (Either (Absence (BasicAuth' x scheme m e a)) (Attribute (BasicAuth' x scheme m e a) Request))
   getTrait _ =
     let schemeName = "http" <> fromString (symbolVal (Proxy @scheme))
         scheme =

--- a/webgear-openapi/src/WebGear/OpenApi/Trait/Auth/Basic.hs
+++ b/webgear-openapi/src/WebGear/OpenApi/Trait/Auth/Basic.hs
@@ -8,12 +8,12 @@ import Data.Proxy (Proxy (..))
 import Data.String (fromString)
 import GHC.TypeLits (KnownSymbol, symbolVal)
 import WebGear.Core.Request (Request)
-import WebGear.Core.Trait (Attribute, Get (..), TraitAbsence (Absence), With)
+import WebGear.Core.Trait (Attribute, Absence, Get (..), With)
 import WebGear.Core.Trait.Auth.Basic (BasicAuth' (..))
 import WebGear.OpenApi.Handler (OpenApiHandler (..))
 import WebGear.OpenApi.Trait.Auth (addSecurityScheme)
 
-instance (TraitAbsence (BasicAuth' x scheme m e a) Request, KnownSymbol scheme) => Get (OpenApiHandler m) (BasicAuth' x scheme m e a) Request where
+instance (KnownSymbol scheme) => Get (OpenApiHandler m) (BasicAuth' x scheme m e a) Request where
   {-# INLINE getTrait #-}
   getTrait ::
     BasicAuth' x scheme m e a ->

--- a/webgear-openapi/src/WebGear/OpenApi/Trait/Auth/JWT.hs
+++ b/webgear-openapi/src/WebGear/OpenApi/Trait/Auth/JWT.hs
@@ -8,19 +8,16 @@ import Data.String (fromString)
 import Data.Typeable (Proxy (..))
 import GHC.TypeLits (KnownSymbol, symbolVal)
 import WebGear.Core.Request (Request)
-import WebGear.Core.Trait (Attribute, Absence, Get (..), With)
+import WebGear.Core.Trait (Absence, Attribute, Get (..), With)
 import WebGear.Core.Trait.Auth.JWT (JWTAuth' (..))
 import WebGear.OpenApi.Handler (OpenApiHandler (..))
 import WebGear.OpenApi.Trait.Auth (addSecurityScheme)
 
-instance
-  (KnownSymbol scheme) =>
-  Get (OpenApiHandler m) (JWTAuth' x scheme m e a) Request
-  where
+instance (KnownSymbol scheme) => Get (OpenApiHandler m) (JWTAuth' x scheme m e a) where
   {-# INLINE getTrait #-}
   getTrait ::
     JWTAuth' x scheme m e a ->
-    OpenApiHandler m (Request `With` ts) (Either (Absence (JWTAuth' x scheme m e a) Request) (Attribute (JWTAuth' x scheme m e a) Request))
+    OpenApiHandler m (Request `With` ts) (Either (Absence (JWTAuth' x scheme m e a)) (Attribute (JWTAuth' x scheme m e a) Request))
   getTrait _ =
     let schemeName = "http" <> fromString (symbolVal (Proxy @scheme))
         scheme =

--- a/webgear-openapi/src/WebGear/OpenApi/Trait/Auth/JWT.hs
+++ b/webgear-openapi/src/WebGear/OpenApi/Trait/Auth/JWT.hs
@@ -8,13 +8,13 @@ import Data.String (fromString)
 import Data.Typeable (Proxy (..))
 import GHC.TypeLits (KnownSymbol, symbolVal)
 import WebGear.Core.Request (Request)
-import WebGear.Core.Trait (Attribute, Get (..), TraitAbsence (..), With)
+import WebGear.Core.Trait (Attribute, Absence, Get (..), With)
 import WebGear.Core.Trait.Auth.JWT (JWTAuth' (..))
 import WebGear.OpenApi.Handler (OpenApiHandler (..))
 import WebGear.OpenApi.Trait.Auth (addSecurityScheme)
 
 instance
-  (TraitAbsence (JWTAuth' x scheme m e a) Request, KnownSymbol scheme) =>
+  (KnownSymbol scheme) =>
   Get (OpenApiHandler m) (JWTAuth' x scheme m e a) Request
   where
   {-# INLINE getTrait #-}

--- a/webgear-openapi/src/WebGear/OpenApi/Trait/Body.hs
+++ b/webgear-openapi/src/WebGear/OpenApi/Trait/Body.hs
@@ -45,7 +45,7 @@ import WebGear.OpenApi.Handler (
   consumeDescription,
  )
 
-instance (ToSchema val, MIMEType mt) => Get (OpenApiHandler m) (Body mt val) Request where
+instance (ToSchema val, MIMEType mt) => Get (OpenApiHandler m) (Body mt val) where
   {-# INLINE getTrait #-}
   getTrait :: Body mt val -> OpenApiHandler m (Request `With` ts) (Either Text val)
   getTrait (Body mt) =
@@ -62,7 +62,7 @@ instance (ToSchema val, MIMEType mt) => Get (OpenApiHandler m) (Body mt val) Req
           & allOperations . requestBody ?~ Inline body
           & components . schemas %~ (<> defs)
 
-instance (ToSchema val, MIMEType mt) => Set (OpenApiHandler m) (Body mt val) WG.Response where
+instance (ToSchema val, MIMEType mt) => Set (OpenApiHandler m) (Body mt val) where
   {-# INLINE setTrait #-}
   setTrait ::
     Body mt val ->
@@ -74,7 +74,7 @@ instance (ToSchema val, MIMEType mt) => Set (OpenApiHandler m) (Body mt val) WG.
         body = mempty @MediaTypeObject & schema ?~ ref
      in OpenApiHandler $ addResponseBody defs (fromList [(mediaType, body)])
 
-instance Set (OpenApiHandler m) UnknownContentBody WG.Response where
+instance Set (OpenApiHandler m) UnknownContentBody where
   {-# INLINE setTrait #-}
   setTrait ::
     UnknownContentBody ->

--- a/webgear-openapi/src/WebGear/OpenApi/Trait/Cookie.hs
+++ b/webgear-openapi/src/WebGear/OpenApi/Trait/Cookie.hs
@@ -10,12 +10,12 @@ import Data.Text (Text)
 import GHC.TypeLits (KnownSymbol, symbolVal)
 import WebGear.Core.Request (Request)
 import WebGear.Core.Response (Response)
-import WebGear.Core.Trait (Get (..), Set (..), Trait, TraitAbsence)
+import WebGear.Core.Trait (Get (..), Set (..))
 import qualified WebGear.Core.Trait.Cookie as WG
 import WebGear.OpenApi.Handler (OpenApiHandler (..))
 import WebGear.OpenApi.Trait.Auth (addSecurityScheme)
 
-instance (KnownSymbol name, TraitAbsence (WG.Cookie e name val) Request) => Get (OpenApiHandler m) (WG.Cookie e name val) Request where
+instance (KnownSymbol name) => Get (OpenApiHandler m) (WG.Cookie e name val) Request where
   {-# INLINE getTrait #-}
   getTrait WG.Cookie =
     OpenApiHandler $ addSecurityScheme cookieName securityScheme
@@ -36,6 +36,6 @@ instance (KnownSymbol name, TraitAbsence (WG.Cookie e name val) Request) => Get 
 
 -- Response cookie information is not captured by OpenAPI
 
-instance (Trait (WG.SetCookie e name) Response) => Set (OpenApiHandler m) (WG.SetCookie e name) Response where
+instance Set (OpenApiHandler m) (WG.SetCookie e name) Response where
   {-# INLINE setTrait #-}
   setTrait WG.SetCookie _ = OpenApiHandler pure

--- a/webgear-openapi/src/WebGear/OpenApi/Trait/Cookie.hs
+++ b/webgear-openapi/src/WebGear/OpenApi/Trait/Cookie.hs
@@ -8,14 +8,12 @@ import Data.Proxy (Proxy (Proxy))
 import Data.String (fromString)
 import Data.Text (Text)
 import GHC.TypeLits (KnownSymbol, symbolVal)
-import WebGear.Core.Request (Request)
-import WebGear.Core.Response (Response)
 import WebGear.Core.Trait (Get (..), Set (..))
 import qualified WebGear.Core.Trait.Cookie as WG
 import WebGear.OpenApi.Handler (OpenApiHandler (..))
 import WebGear.OpenApi.Trait.Auth (addSecurityScheme)
 
-instance (KnownSymbol name) => Get (OpenApiHandler m) (WG.Cookie e name val) Request where
+instance (KnownSymbol name) => Get (OpenApiHandler m) (WG.Cookie e name val) where
   {-# INLINE getTrait #-}
   getTrait WG.Cookie =
     OpenApiHandler $ addSecurityScheme cookieName securityScheme
@@ -36,6 +34,6 @@ instance (KnownSymbol name) => Get (OpenApiHandler m) (WG.Cookie e name val) Req
 
 -- Response cookie information is not captured by OpenAPI
 
-instance Set (OpenApiHandler m) (WG.SetCookie e name) Response where
+instance Set (OpenApiHandler m) (WG.SetCookie e name) where
   {-# INLINE setTrait #-}
   setTrait WG.SetCookie _ = OpenApiHandler pure

--- a/webgear-openapi/src/WebGear/OpenApi/Trait/Header.hs
+++ b/webgear-openapi/src/WebGear/OpenApi/Trait/Header.hs
@@ -35,15 +35,15 @@ import WebGear.Core.Handler (Description (..))
 import WebGear.Core.Modifiers (Existence (..))
 import WebGear.Core.Request (Request)
 import qualified WebGear.Core.Response as WG
-import WebGear.Core.Trait (Get (..), Set (..), TraitAbsence)
+import WebGear.Core.Trait (Get (..), Set (..))
 import qualified WebGear.Core.Trait.Header as WG
 import WebGear.OpenApi.Handler (Documentation, OpenApiHandler (..), consumeDescription)
 
-instance (KnownSymbol name, ToSchema val, TraitAbsence (WG.RequestHeader Required ps name val) Request) => Get (OpenApiHandler m) (WG.RequestHeader Required ps name val) Request where
+instance (KnownSymbol name, ToSchema val) => Get (OpenApiHandler m) (WG.RequestHeader Required ps name val) Request where
   {-# INLINE getTrait #-}
   getTrait WG.RequestHeader = OpenApiHandler $ addRequestHeader (Proxy @name) (Proxy @val) True
 
-instance (KnownSymbol name, ToSchema val, TraitAbsence (WG.RequestHeader Optional ps name val) Request) => Get (OpenApiHandler m) (WG.RequestHeader Optional ps name val) Request where
+instance (KnownSymbol name, ToSchema val) => Get (OpenApiHandler m) (WG.RequestHeader Optional ps name val) Request where
   {-# INLINE getTrait #-}
   getTrait WG.RequestHeader = OpenApiHandler $ addRequestHeader (Proxy @name) (Proxy @val) False
 

--- a/webgear-openapi/src/WebGear/OpenApi/Trait/Header.hs
+++ b/webgear-openapi/src/WebGear/OpenApi/Trait/Header.hs
@@ -33,25 +33,23 @@ import Data.Text (Text)
 import GHC.TypeLits (KnownSymbol, symbolVal)
 import WebGear.Core.Handler (Description (..))
 import WebGear.Core.Modifiers (Existence (..))
-import WebGear.Core.Request (Request)
-import qualified WebGear.Core.Response as WG
 import WebGear.Core.Trait (Get (..), Set (..))
 import qualified WebGear.Core.Trait.Header as WG
 import WebGear.OpenApi.Handler (Documentation, OpenApiHandler (..), consumeDescription)
 
-instance (KnownSymbol name, ToSchema val) => Get (OpenApiHandler m) (WG.RequestHeader Required ps name val) Request where
+instance (KnownSymbol name, ToSchema val) => Get (OpenApiHandler m) (WG.RequestHeader Required ps name val) where
   {-# INLINE getTrait #-}
   getTrait WG.RequestHeader = OpenApiHandler $ addRequestHeader (Proxy @name) (Proxy @val) True
 
-instance (KnownSymbol name, ToSchema val) => Get (OpenApiHandler m) (WG.RequestHeader Optional ps name val) Request where
+instance (KnownSymbol name, ToSchema val) => Get (OpenApiHandler m) (WG.RequestHeader Optional ps name val) where
   {-# INLINE getTrait #-}
   getTrait WG.RequestHeader = OpenApiHandler $ addRequestHeader (Proxy @name) (Proxy @val) False
 
-instance (KnownSymbol name, ToSchema val) => Set (OpenApiHandler m) (WG.ResponseHeader Required name val) WG.Response where
+instance (KnownSymbol name, ToSchema val) => Set (OpenApiHandler m) (WG.ResponseHeader Required name val) where
   {-# INLINE setTrait #-}
   setTrait WG.ResponseHeader _ = OpenApiHandler $ addResponseHeader (Proxy @name) (Proxy @val) True
 
-instance (KnownSymbol name, ToSchema val) => Set (OpenApiHandler m) (WG.ResponseHeader Optional name val) WG.Response where
+instance (KnownSymbol name, ToSchema val) => Set (OpenApiHandler m) (WG.ResponseHeader Optional name val) where
   {-# INLINE setTrait #-}
   setTrait WG.ResponseHeader _ = OpenApiHandler $ addResponseHeader (Proxy @name) (Proxy @val) False
 

--- a/webgear-openapi/src/WebGear/OpenApi/Trait/Method.hs
+++ b/webgear-openapi/src/WebGear/OpenApi/Trait/Method.hs
@@ -7,12 +7,11 @@ import Control.Lens ((%~), (&))
 import qualified Data.HashMap.Strict.InsOrd as Map
 import Data.OpenApi (PathItem (..), paths)
 import Network.HTTP.Types (StdMethod (..))
-import WebGear.Core.Request (Request)
 import WebGear.Core.Trait (Get (..))
 import WebGear.Core.Trait.Method (Method (..))
 import WebGear.OpenApi.Handler (OpenApiHandler (..), addRouteDocumentation)
 
-instance Get (OpenApiHandler m) Method Request where
+instance Get (OpenApiHandler m) Method where
   {-# INLINE getTrait #-}
   getTrait (Method method) = OpenApiHandler $ \doc -> do
     addRouteDocumentation $ doc & paths %~ Map.map (removeOtherMethods method)

--- a/webgear-openapi/src/WebGear/OpenApi/Trait/Path.hs
+++ b/webgear-openapi/src/WebGear/OpenApi/Trait/Path.hs
@@ -23,12 +23,12 @@ import WebGear.Core.Trait (Get (..), With)
 import WebGear.Core.Trait.Path (Path (..), PathEnd (..), PathVar (..), PathVarError (..))
 import WebGear.OpenApi.Handler (OpenApiHandler (..), addRouteDocumentation)
 
-instance Get (OpenApiHandler m) Path Request where
+instance Get (OpenApiHandler m) Path where
   {-# INLINE getTrait #-}
   getTrait :: Path -> OpenApiHandler m (Request `With` ts) (Either () ())
   getTrait (Path p) = OpenApiHandler $ addRouteDocumentation . prependPath (unpack p)
 
-instance (KnownSymbol tag, ToSchema val) => Get (OpenApiHandler m) (PathVar tag val) Request where
+instance (KnownSymbol tag, ToSchema val) => Get (OpenApiHandler m) (PathVar tag val) where
   {-# INLINE getTrait #-}
   getTrait :: PathVar tag val -> OpenApiHandler m (Request `With` ts) (Either PathVarError val)
   getTrait PathVar =
@@ -45,7 +45,7 @@ instance (KnownSymbol tag, ToSchema val) => Get (OpenApiHandler m) (PathVar tag 
             prependPath ("{" <> paramName <> "}") doc
               & allOperations . parameters <>~ [Inline param]
 
-instance Get (OpenApiHandler m) PathEnd Request where
+instance Get (OpenApiHandler m) PathEnd where
   {-# INLINE getTrait #-}
   getTrait :: PathEnd -> OpenApiHandler m (Request `With` ts) (Either () ())
   getTrait PathEnd = OpenApiHandler $ addRouteDocumentation . prependPath "/"

--- a/webgear-openapi/src/WebGear/OpenApi/Trait/QueryParam.hs
+++ b/webgear-openapi/src/WebGear/OpenApi/Trait/QueryParam.hs
@@ -22,11 +22,11 @@ import GHC.TypeLits (KnownSymbol, symbolVal)
 import WebGear.Core.Handler (Description (..))
 import WebGear.Core.Modifiers (Existence (..))
 import WebGear.Core.Request (Request)
-import WebGear.Core.Trait (Get (..), TraitAbsence)
+import WebGear.Core.Trait (Get (..))
 import WebGear.Core.Trait.QueryParam (QueryParam (..))
 import WebGear.OpenApi.Handler (Documentation (..), OpenApiHandler (..), consumeDescription)
 
-instance (KnownSymbol name, ToSchema val, TraitAbsence (QueryParam Required ps name val) Request) => Get (OpenApiHandler m) (QueryParam Required ps name val) Request where
+instance (KnownSymbol name, ToSchema val) => Get (OpenApiHandler m) (QueryParam Required ps name val) Request where
   {-# INLINE getTrait #-}
   getTrait _ =
     let param =
@@ -38,7 +38,7 @@ instance (KnownSymbol name, ToSchema val, TraitAbsence (QueryParam Required ps n
             }
      in OpenApiHandler $ addParam param
 
-instance (KnownSymbol name, ToSchema val, TraitAbsence (QueryParam Optional ps name val) Request) => Get (OpenApiHandler m) (QueryParam Optional ps name val) Request where
+instance (KnownSymbol name, ToSchema val) => Get (OpenApiHandler m) (QueryParam Optional ps name val) Request where
   {-# INLINE getTrait #-}
   getTrait _ =
     let param =

--- a/webgear-openapi/src/WebGear/OpenApi/Trait/QueryParam.hs
+++ b/webgear-openapi/src/WebGear/OpenApi/Trait/QueryParam.hs
@@ -21,12 +21,11 @@ import Data.String (fromString)
 import GHC.TypeLits (KnownSymbol, symbolVal)
 import WebGear.Core.Handler (Description (..))
 import WebGear.Core.Modifiers (Existence (..))
-import WebGear.Core.Request (Request)
 import WebGear.Core.Trait (Get (..))
 import WebGear.Core.Trait.QueryParam (QueryParam (..))
 import WebGear.OpenApi.Handler (Documentation (..), OpenApiHandler (..), consumeDescription)
 
-instance (KnownSymbol name, ToSchema val) => Get (OpenApiHandler m) (QueryParam Required ps name val) Request where
+instance (KnownSymbol name, ToSchema val) => Get (OpenApiHandler m) (QueryParam Required ps name val) where
   {-# INLINE getTrait #-}
   getTrait _ =
     let param =
@@ -38,7 +37,7 @@ instance (KnownSymbol name, ToSchema val) => Get (OpenApiHandler m) (QueryParam 
             }
      in OpenApiHandler $ addParam param
 
-instance (KnownSymbol name, ToSchema val) => Get (OpenApiHandler m) (QueryParam Optional ps name val) Request where
+instance (KnownSymbol name, ToSchema val) => Get (OpenApiHandler m) (QueryParam Optional ps name val) where
   {-# INLINE getTrait #-}
   getTrait _ =
     let param =

--- a/webgear-openapi/src/WebGear/OpenApi/Trait/Status.hs
+++ b/webgear-openapi/src/WebGear/OpenApi/Trait/Status.hs
@@ -31,7 +31,7 @@ import WebGear.Core.Trait (Set, With, setTrait)
 import WebGear.Core.Trait.Status (Status (..))
 import WebGear.OpenApi.Handler (OpenApiHandler (..), addRootPath, consumeDescription)
 
-instance Set (OpenApiHandler m) Status WG.Response where
+instance Set (OpenApiHandler m) Status where
   {-# INLINE setTrait #-}
   setTrait ::
     Status ->

--- a/webgear-server/CHANGELOG.md
+++ b/webgear-server/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Simplify core API (breaking change) (#47)
+
 ## [1.2.0] - 2024-03-18
 
 ### Added

--- a/webgear-server/src/WebGear/Server/Trait/Auth/Basic.hs
+++ b/webgear-server/src/WebGear/Server/Trait/Auth/Basic.hs
@@ -26,7 +26,7 @@ import WebGear.Core.Trait.Auth.Common (
  )
 import WebGear.Server.Handler (ServerHandler)
 
-instance (Monad m) => Get (ServerHandler m) (BasicAuth' Required scheme m e a) Request where
+instance (Monad m) => Get (ServerHandler m) (BasicAuth' Required scheme m e a) where
   {-# INLINE getTrait #-}
   getTrait ::
     (HasTrait (AuthorizationHeader scheme) ts) =>
@@ -53,7 +53,7 @@ instance (Monad m) => Get (ServerHandler m) (BasicAuth' Required scheme m e a) R
         res <- toBasicAttribute creds
         pure $ first BasicAuthAttributeError res
 
-instance (Monad m) => Get (ServerHandler m) (BasicAuth' Optional scheme m e a) Request where
+instance (Monad m) => Get (ServerHandler m) (BasicAuth' Optional scheme m e a) where
   {-# INLINE getTrait #-}
   getTrait ::
     (HasTrait (AuthorizationHeader scheme) ts) =>

--- a/webgear-server/src/WebGear/Server/Trait/Auth/JWT.hs
+++ b/webgear-server/src/WebGear/Server/Trait/Auth/JWT.hs
@@ -22,7 +22,7 @@ import WebGear.Core.Trait.Auth.Common (
 import WebGear.Core.Trait.Auth.JWT (JWTAuth' (..), JWTAuthError (..))
 import WebGear.Server.Handler (ServerHandler)
 
-instance (MonadTime m, Get (ServerHandler m) (AuthorizationHeader scheme) Request) => Get (ServerHandler m) (JWTAuth' Required scheme m e a) Request where
+instance (MonadTime m, Get (ServerHandler m) (AuthorizationHeader scheme)) => Get (ServerHandler m) (JWTAuth' Required scheme m e a) where
   {-# INLINE getTrait #-}
   getTrait ::
     (HasTrait (AuthorizationHeader scheme) ts) =>
@@ -46,7 +46,7 @@ instance (MonadTime m, Get (ServerHandler m) (AuthorizationHeader scheme) Reques
         claims <- withExceptT JWTAuthTokenBadFormat $ JWT.verifyClaims jwtValidationSettings jwkSet jwt
         lift (toJWTAttribute claims) >>= either (throwError . JWTAuthAttributeError) pure
 
-instance (MonadTime m, Get (ServerHandler m) (AuthorizationHeader scheme) Request) => Get (ServerHandler m) (JWTAuth' Optional scheme m e a) Request where
+instance (MonadTime m, Get (ServerHandler m) (AuthorizationHeader scheme)) => Get (ServerHandler m) (JWTAuth' Optional scheme m e a) where
   {-# INLINE getTrait #-}
   getTrait ::
     (HasTrait (AuthorizationHeader scheme) ts) =>

--- a/webgear-server/src/WebGear/Server/Trait/Body.hs
+++ b/webgear-server/src/WebGear/Server/Trait/Body.hs
@@ -16,12 +16,12 @@ import WebGear.Core.Trait.Body (Body (..), UnknownContentBody (..))
 import WebGear.Server.Handler (ServerHandler (..))
 import WebGear.Server.MIMETypes (BodyRender (..), BodyUnrender (..))
 
-instance (Monad m, BodyUnrender m mt val) => Get (ServerHandler m) (Body mt val) Request where
+instance (Monad m, BodyUnrender m mt val) => Get (ServerHandler m) (Body mt val) where
   {-# INLINE getTrait #-}
   getTrait :: Body mt val -> ServerHandler m (Request `With` ts) (Either Text val)
   getTrait (Body mt) = arrM $ bodyUnrender mt . unwitness
 
-instance (Monad m, BodyRender m mt val) => Set (ServerHandler m) (Body mt val) Response where
+instance (Monad m, BodyRender m mt val) => Set (ServerHandler m) (Body mt val) where
   {-# INLINE setTrait #-}
   setTrait ::
     Body mt val ->
@@ -45,7 +45,7 @@ alterContentType mt = go
       | n == HTTP.hContentType = (HTTP.hContentType, mtStr) : hdrs
       | otherwise = (n, v) : go hdrs
 
-instance (Monad m) => Set (ServerHandler m) UnknownContentBody Response where
+instance (Monad m) => Set (ServerHandler m) UnknownContentBody where
   {-# INLINE setTrait #-}
   setTrait ::
     UnknownContentBody ->

--- a/webgear-server/src/WebGear/Server/Trait/Cookie.hs
+++ b/webgear-server/src/WebGear/Server/Trait/Cookie.hs
@@ -21,7 +21,7 @@ import WebGear.Core.Trait (Get (..), Set (..), With, unwitness)
 import WebGear.Core.Trait.Cookie (Cookie (..), CookieNotFound (..), CookieParseError (..), SetCookie (..))
 import WebGear.Server.Handler (ServerHandler)
 
-instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler m) (Cookie Required name val) Request where
+instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler m) (Cookie Required name val) where
   {-# INLINE getTrait #-}
   getTrait ::
     Cookie Required name val ->
@@ -33,7 +33,7 @@ instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler 
         Just (Left e) -> Left $ Right $ CookieParseError e
         Just (Right x) -> Right x
 
-instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler m) (Cookie Optional name val) Request where
+instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler m) (Cookie Optional name val) where
   {-# INLINE getTrait #-}
   getTrait ::
     Cookie Optional name val ->
@@ -60,7 +60,7 @@ extractCookie proxy = proc req -> do
 
   returnA -< parseHeader <$> lookupCookie
 
-instance (Monad m, KnownSymbol name) => Set (ServerHandler m) (SetCookie Required name) Response where
+instance (Monad m, KnownSymbol name) => Set (ServerHandler m) (SetCookie Required name) where
   {-# INLINE setTrait #-}
   setTrait ::
     SetCookie Required name ->
@@ -75,7 +75,7 @@ instance (Monad m, KnownSymbol name) => Set (ServerHandler m) (SetCookie Require
             _ -> response
     returnA -< f l response' cookie
 
-instance (Monad m, KnownSymbol name) => Set (ServerHandler m) (SetCookie Optional name) Response where
+instance (Monad m, KnownSymbol name) => Set (ServerHandler m) (SetCookie Optional name) where
   {-# INLINE setTrait #-}
   -- If the optional value is 'Nothing', the cookie is removed from the response
   setTrait ::

--- a/webgear-server/src/WebGear/Server/Trait/Header.hs
+++ b/webgear-server/src/WebGear/Server/Trait/Header.hs
@@ -29,7 +29,7 @@ extractRequestHeader proxy = proc req -> do
   let headerName :: HeaderName = fromString $ symbolVal proxy
   returnA -< parseHeader <$> requestHeader headerName (unwitness req)
 
-instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler m) (RequestHeader Required Strict name val) Request where
+instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler m) (RequestHeader Required Strict name val) where
   {-# INLINE getTrait #-}
   getTrait ::
     RequestHeader Required Strict name val ->
@@ -41,7 +41,7 @@ instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler 
         Just (Left e) -> Left $ Right $ HeaderParseError e
         Just (Right x) -> Right x
 
-instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler m) (RequestHeader Optional Strict name val) Request where
+instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler m) (RequestHeader Optional Strict name val) where
   {-# INLINE getTrait #-}
   getTrait ::
     RequestHeader Optional Strict name val ->
@@ -53,7 +53,7 @@ instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler 
         Just (Left e) -> Left $ HeaderParseError e
         Just (Right x) -> Right $ Just x
 
-instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler m) (RequestHeader Required Lenient name val) Request where
+instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler m) (RequestHeader Required Lenient name val) where
   {-# INLINE getTrait #-}
   getTrait ::
     RequestHeader Required Lenient name val ->
@@ -65,7 +65,7 @@ instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler 
         Just (Left e) -> Right $ Left e
         Just (Right x) -> Right $ Right x
 
-instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler m) (RequestHeader Optional Lenient name val) Request where
+instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler m) (RequestHeader Optional Lenient name val) where
   {-# INLINE getTrait #-}
   getTrait ::
     RequestHeader Optional Lenient name val ->
@@ -77,7 +77,7 @@ instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler 
         Just (Left e) -> Right $ Just $ Left e
         Just (Right x) -> Right $ Just $ Right x
 
-instance (Monad m, KnownSymbol name, ToHttpApiData val) => Set (ServerHandler m) (ResponseHeader Required name val) Response where
+instance (Monad m, KnownSymbol name, ToHttpApiData val) => Set (ServerHandler m) (ResponseHeader Required name val) where
   {-# INLINE setTrait #-}
   setTrait ::
     ResponseHeader Required name val ->
@@ -92,7 +92,7 @@ instance (Monad m, KnownSymbol name, ToHttpApiData val) => Set (ServerHandler m)
             _ -> response
     returnA -< f l response' val
 
-instance (Monad m, KnownSymbol name, ToHttpApiData val) => Set (ServerHandler m) (ResponseHeader Optional name val) Response where
+instance (Monad m, KnownSymbol name, ToHttpApiData val) => Set (ServerHandler m) (ResponseHeader Optional name val) where
   {-# INLINE setTrait #-}
   -- If the optional value is 'Nothing', the header is removed from the response
   setTrait ::

--- a/webgear-server/src/WebGear/Server/Trait/Method.hs
+++ b/webgear-server/src/WebGear/Server/Trait/Method.hs
@@ -10,7 +10,7 @@ import WebGear.Core.Trait (Get (..), With (unwitness), unwitness)
 import WebGear.Core.Trait.Method (Method (..), MethodMismatch (..))
 import WebGear.Server.Handler (ServerHandler)
 
-instance (Monad m) => Get (ServerHandler m) Method Request where
+instance (Monad m) => Get (ServerHandler m) Method where
   {-# INLINE getTrait #-}
   getTrait :: Method -> ServerHandler m (Request `With` ts) (Either MethodMismatch HTTP.StdMethod)
   getTrait (Method method) = proc request -> do

--- a/webgear-server/src/WebGear/Server/Trait/Path.hs
+++ b/webgear-server/src/WebGear/Server/Trait/Path.hs
@@ -18,7 +18,7 @@ import WebGear.Core.Trait.Path (
  )
 import WebGear.Server.Handler (ServerHandler (..))
 
-instance (Monad m) => Get (ServerHandler m) Path Request where
+instance (Monad m) => Get (ServerHandler m) Path where
   {-# INLINE getTrait #-}
   getTrait :: Path -> ServerHandler m (Request `With` ts) (Either () ())
   getTrait (Path p) = ServerHandler $ const $ do
@@ -28,7 +28,7 @@ instance (Monad m) => Get (ServerHandler m) Path Request where
       Just ps -> put (RoutePath ps) >> pure (Right ())
       Nothing -> pure (Left ())
 
-instance (Monad m, FromHttpApiData val) => Get (ServerHandler m) (PathVar tag val) Request where
+instance (Monad m, FromHttpApiData val) => Get (ServerHandler m) (PathVar tag val) where
   {-# INLINE getTrait #-}
   getTrait :: PathVar tag val -> ServerHandler m (Request `With` ts) (Either PathVarError val)
   getTrait PathVar = ServerHandler $ const $ do
@@ -40,14 +40,14 @@ instance (Monad m, FromHttpApiData val) => Get (ServerHandler m) (PathVar tag va
           Left e -> pure (Left $ PathVarParseError e)
           Right val -> put (RoutePath ps) >> pure (Right val)
 
-instance (Monad m) => Get (ServerHandler m) PathEnd Request where
+instance (Monad m) => Get (ServerHandler m) PathEnd where
   {-# INLINE getTrait #-}
   getTrait :: PathEnd -> ServerHandler m (Request `With` ts) (Either () ())
   getTrait PathEnd =
-    ServerHandler
-      $ const
-      $ gets
-        ( \case
-            RoutePath [] -> Right ()
-            _ -> Left ()
-        )
+    ServerHandler $
+      const $
+        gets
+          ( \case
+              RoutePath [] -> Right ()
+              _ -> Left ()
+          )

--- a/webgear-server/src/WebGear/Server/Trait/QueryParam.hs
+++ b/webgear-server/src/WebGear/Server/Trait/QueryParam.hs
@@ -31,7 +31,7 @@ extractQueryParam proxy = proc req -> do
       params = queryToQueryText $ queryString $ unwitness req
   returnA -< parseQueryParam <$> (find ((== name) . fst) params >>= snd)
 
-instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler m) (QueryParam Required Strict name val) Request where
+instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler m) (QueryParam Required Strict name val) where
   {-# INLINE getTrait #-}
   getTrait ::
     QueryParam Required Strict name val ->
@@ -43,7 +43,7 @@ instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler 
         Just (Left e) -> Left $ Right $ ParamParseError e
         Just (Right x) -> Right x
 
-instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler m) (QueryParam Optional Strict name val) Request where
+instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler m) (QueryParam Optional Strict name val) where
   {-# INLINE getTrait #-}
   getTrait ::
     QueryParam Optional Strict name val ->
@@ -55,7 +55,7 @@ instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler 
         Just (Left e) -> Left $ ParamParseError e
         Just (Right x) -> Right $ Just x
 
-instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler m) (QueryParam Required Lenient name val) Request where
+instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler m) (QueryParam Required Lenient name val) where
   {-# INLINE getTrait #-}
   getTrait ::
     QueryParam Required Lenient name val ->
@@ -67,7 +67,7 @@ instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler 
         Just (Left e) -> Right $ Left e
         Just (Right x) -> Right $ Right x
 
-instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler m) (QueryParam Optional Lenient name val) Request where
+instance (Monad m, KnownSymbol name, FromHttpApiData val) => Get (ServerHandler m) (QueryParam Optional Lenient name val) where
   {-# INLINE getTrait #-}
   getTrait ::
     QueryParam Optional Lenient name val ->

--- a/webgear-server/src/WebGear/Server/Trait/Status.hs
+++ b/webgear-server/src/WebGear/Server/Trait/Status.hs
@@ -10,7 +10,7 @@ import WebGear.Core.Trait (Set, With, setTrait, unwitness)
 import WebGear.Core.Trait.Status (Status (..))
 import WebGear.Server.Handler (ServerHandler)
 
-instance (Monad m) => Set (ServerHandler m) Status Response where
+instance (Monad m) => Set (ServerHandler m) Status where
   {-# INLINE setTrait #-}
   setTrait ::
     Status ->

--- a/webgear-swagger-ui/CHANGELOG.md
+++ b/webgear-swagger-ui/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Simplify core API (breaking change) (#47)
+
 ## [1.2.0] - 2024-03-18
 
 ### Changed

--- a/webgear-swagger-ui/src/WebGear/Swagger/UI.hs
+++ b/webgear-swagger-ui/src/WebGear/Swagger/UI.hs
@@ -16,7 +16,6 @@ import WebGear.Core (
   JSON (..),
   RequestHandler,
   RequiredResponseHeader,
-  Response (..),
   Sets,
   StdHandler,
   UnknownContentBody,
@@ -45,7 +44,6 @@ swaggerUI ::
       , Body JSON apiSpec
       , UnknownContentBody
       ]
-      Response
   ) =>
   -- | Swagger 2.0 or OpenAPI 3.x specification
   apiSpec ->
@@ -58,21 +56,21 @@ swaggerUI apiSpec =
 
 rootEndpoint ::
   ( StdHandler h m
-  , Sets h [RequiredResponseHeader "Content-Type" Text, Body HTML ByteString] Response
+  , Sets h [RequiredResponseHeader "Content-Type" Text, Body HTML ByteString]
   ) =>
   RequestHandler h ts
 rootEndpoint = method HTTP.GET $ pathEnd serveIndexHtml
 
 indexHtml ::
   ( StdHandler h m
-  , Sets h [RequiredResponseHeader "Content-Type" Text, Body HTML ByteString] Response
+  , Sets h [RequiredResponseHeader "Content-Type" Text, Body HTML ByteString]
   ) =>
   RequestHandler h ts
 indexHtml = [route| HTTP.GET /index.html |] serveIndexHtml
 
 serveIndexHtml ::
   ( StdHandler h m
-  , Sets h [RequiredResponseHeader "Content-Type" Text, Body HTML ByteString] Response
+  , Sets h [RequiredResponseHeader "Content-Type" Text, Body HTML ByteString]
   ) =>
   RequestHandler h ts
 serveIndexHtml = proc _request ->
@@ -80,7 +78,7 @@ serveIndexHtml = proc _request ->
 
 swaggerJson ::
   ( StdHandler h m
-  , Sets h [RequiredResponseHeader "Content-Type" Text, Body JSON apiSpec] Response
+  , Sets h [RequiredResponseHeader "Content-Type" Text, Body JSON apiSpec]
   ) =>
   -- | Swagger 2.0 or OpenAPI 3.x specification
   apiSpec ->

--- a/webgear-swagger/CHANGELOG.md
+++ b/webgear-swagger/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Changed
+- Simplify core API (breaking change) (#47)
 - Reimplement Swagger/OpenAPI internals (#45)
 
 ## [1.2.0] - 2024-03-18

--- a/webgear-swagger/src/WebGear/Swagger/Trait/Auth/Basic.hs
+++ b/webgear-swagger/src/WebGear/Swagger/Trait/Auth/Basic.hs
@@ -8,12 +8,12 @@ import Data.String (fromString)
 import Data.Swagger
 import GHC.TypeLits (KnownSymbol, symbolVal)
 import WebGear.Core.Request (Request)
-import WebGear.Core.Trait (Attribute, Get (..), TraitAbsence (Absence), With)
+import WebGear.Core.Trait (Attribute, Get (..), Absence, With)
 import WebGear.Core.Trait.Auth.Basic (BasicAuth' (..))
 import WebGear.Swagger.Handler (SwaggerHandler (..))
 import WebGear.Swagger.Trait.Auth (addSecurityScheme)
 
-instance (TraitAbsence (BasicAuth' x scheme m e a) Request, KnownSymbol scheme) => Get (SwaggerHandler m) (BasicAuth' x scheme m e a) Request where
+instance (KnownSymbol scheme) => Get (SwaggerHandler m) (BasicAuth' x scheme m e a) Request where
   {-# INLINE getTrait #-}
   getTrait ::
     BasicAuth' x scheme m e a ->

--- a/webgear-swagger/src/WebGear/Swagger/Trait/Auth/Basic.hs
+++ b/webgear-swagger/src/WebGear/Swagger/Trait/Auth/Basic.hs
@@ -8,16 +8,16 @@ import Data.String (fromString)
 import Data.Swagger
 import GHC.TypeLits (KnownSymbol, symbolVal)
 import WebGear.Core.Request (Request)
-import WebGear.Core.Trait (Attribute, Get (..), Absence, With)
+import WebGear.Core.Trait (Absence, Attribute, Get (..), With)
 import WebGear.Core.Trait.Auth.Basic (BasicAuth' (..))
 import WebGear.Swagger.Handler (SwaggerHandler (..))
 import WebGear.Swagger.Trait.Auth (addSecurityScheme)
 
-instance (KnownSymbol scheme) => Get (SwaggerHandler m) (BasicAuth' x scheme m e a) Request where
+instance (KnownSymbol scheme) => Get (SwaggerHandler m) (BasicAuth' x scheme m e a) where
   {-# INLINE getTrait #-}
   getTrait ::
     BasicAuth' x scheme m e a ->
-    SwaggerHandler m (Request `With` ts) (Either (Absence (BasicAuth' x scheme m e a) Request) (Attribute (BasicAuth' x scheme m e a) Request))
+    SwaggerHandler m (Request `With` ts) (Either (Absence (BasicAuth' x scheme m e a)) (Attribute (BasicAuth' x scheme m e a) Request))
   getTrait _ =
     let schemeName = "http" <> fromString (symbolVal (Proxy @scheme))
         scheme =

--- a/webgear-swagger/src/WebGear/Swagger/Trait/Auth/JWT.hs
+++ b/webgear-swagger/src/WebGear/Swagger/Trait/Auth/JWT.hs
@@ -8,19 +8,16 @@ import Data.Swagger
 import Data.Typeable (Proxy (..))
 import GHC.TypeLits (KnownSymbol, symbolVal)
 import WebGear.Core.Request (Request)
-import WebGear.Core.Trait (Attribute, Get (..), Absence, With)
+import WebGear.Core.Trait (Absence, Attribute, Get (..), With)
 import WebGear.Core.Trait.Auth.JWT (JWTAuth' (..))
 import WebGear.Swagger.Handler (SwaggerHandler (..))
 import WebGear.Swagger.Trait.Auth (addSecurityScheme)
 
-instance
-  (KnownSymbol scheme) =>
-  Get (SwaggerHandler m) (JWTAuth' x scheme m e a) Request
-  where
+instance (KnownSymbol scheme) => Get (SwaggerHandler m) (JWTAuth' x scheme m e a) where
   {-# INLINE getTrait #-}
   getTrait ::
     JWTAuth' x scheme m e a ->
-    SwaggerHandler m (Request `With` ts) (Either (Absence (JWTAuth' x scheme m e a) Request) (Attribute (JWTAuth' x scheme m e a) Request))
+    SwaggerHandler m (Request `With` ts) (Either (Absence (JWTAuth' x scheme m e a)) (Attribute (JWTAuth' x scheme m e a) Request))
   getTrait _ =
     let schemeName = fromString (symbolVal (Proxy @scheme))
         -- Swagger 2.0 does not support JWT: https://stackoverflow.com/a/32995636

--- a/webgear-swagger/src/WebGear/Swagger/Trait/Auth/JWT.hs
+++ b/webgear-swagger/src/WebGear/Swagger/Trait/Auth/JWT.hs
@@ -8,13 +8,13 @@ import Data.Swagger
 import Data.Typeable (Proxy (..))
 import GHC.TypeLits (KnownSymbol, symbolVal)
 import WebGear.Core.Request (Request)
-import WebGear.Core.Trait (Attribute, Get (..), TraitAbsence (..), With)
+import WebGear.Core.Trait (Attribute, Get (..), Absence, With)
 import WebGear.Core.Trait.Auth.JWT (JWTAuth' (..))
 import WebGear.Swagger.Handler (SwaggerHandler (..))
 import WebGear.Swagger.Trait.Auth (addSecurityScheme)
 
 instance
-  (TraitAbsence (JWTAuth' x scheme m e a) Request, KnownSymbol scheme) =>
+  (KnownSymbol scheme) =>
   Get (SwaggerHandler m) (JWTAuth' x scheme m e a) Request
   where
   {-# INLINE getTrait #-}

--- a/webgear-swagger/src/WebGear/Swagger/Trait/Body.hs
+++ b/webgear-swagger/src/WebGear/Swagger/Trait/Body.hs
@@ -46,7 +46,7 @@ import WebGear.Swagger.Handler (
   consumeDescription,
  )
 
-instance (ToSchema val, MIMEType mt) => Get (SwaggerHandler m) (Body mt val) Request where
+instance (ToSchema val, MIMEType mt) => Get (SwaggerHandler m) (Body mt val) where
   {-# INLINE getTrait #-}
   getTrait :: Body mt val -> SwaggerHandler m (Request `With` ts) (Either Text val)
   getTrait (Body mt) =
@@ -70,7 +70,7 @@ instance (ToSchema val, MIMEType mt) => Get (SwaggerHandler m) (Body mt val) Req
                )
           & definitions %~ (<> defs)
 
-instance (ToSchema val, MIMEType mt) => Set (SwaggerHandler m) (Body mt val) WG.Response where
+instance (ToSchema val, MIMEType mt) => Set (SwaggerHandler m) (Body mt val) where
   {-# INLINE setTrait #-}
   setTrait ::
     Body mt val ->
@@ -81,7 +81,7 @@ instance (ToSchema val, MIMEType mt) => Set (SwaggerHandler m) (Body mt val) WG.
         (defs, ref) = runDeclare (declareSchemaRef $ Proxy @val) mempty
      in SwaggerHandler $ addResponseBody defs mimeList (Just ref)
 
-instance Set (SwaggerHandler m) UnknownContentBody WG.Response where
+instance Set (SwaggerHandler m) UnknownContentBody where
   {-# INLINE setTrait #-}
   setTrait ::
     UnknownContentBody ->

--- a/webgear-swagger/src/WebGear/Swagger/Trait/Cookie.hs
+++ b/webgear-swagger/src/WebGear/Swagger/Trait/Cookie.hs
@@ -5,22 +5,16 @@ module WebGear.Swagger.Trait.Cookie () where
 
 import WebGear.Core.Request (Request)
 import WebGear.Core.Response (Response)
-import WebGear.Core.Trait (Get (..), Set (..), Trait, TraitAbsence)
+import WebGear.Core.Trait (Get (..), Set (..))
 import qualified WebGear.Core.Trait.Cookie as WG
 import WebGear.Swagger.Handler (SwaggerHandler (..))
 
 -- Cookie information is not captured by Swagger
 
-instance
-  (TraitAbsence (WG.Cookie e name val) Request) =>
-  Get (SwaggerHandler m) (WG.Cookie e name val) Request
-  where
+instance Get (SwaggerHandler m) (WG.Cookie e name val) Request where
   {-# INLINE getTrait #-}
   getTrait WG.Cookie = SwaggerHandler pure
 
-instance
-  (Trait (WG.SetCookie e name) Response) =>
-  Set (SwaggerHandler m) (WG.SetCookie e name) Response
-  where
+instance Set (SwaggerHandler m) (WG.SetCookie e name) Response where
   {-# INLINE setTrait #-}
   setTrait WG.SetCookie _ = SwaggerHandler pure

--- a/webgear-swagger/src/WebGear/Swagger/Trait/Cookie.hs
+++ b/webgear-swagger/src/WebGear/Swagger/Trait/Cookie.hs
@@ -3,18 +3,16 @@
 -- | Swagger implementation of 'WG.Cookie' and 'WG.SetCookie' traits.
 module WebGear.Swagger.Trait.Cookie () where
 
-import WebGear.Core.Request (Request)
-import WebGear.Core.Response (Response)
 import WebGear.Core.Trait (Get (..), Set (..))
 import qualified WebGear.Core.Trait.Cookie as WG
 import WebGear.Swagger.Handler (SwaggerHandler (..))
 
 -- Cookie information is not captured by Swagger
 
-instance Get (SwaggerHandler m) (WG.Cookie e name val) Request where
+instance Get (SwaggerHandler m) (WG.Cookie e name val) where
   {-# INLINE getTrait #-}
   getTrait WG.Cookie = SwaggerHandler pure
 
-instance Set (SwaggerHandler m) (WG.SetCookie e name) Response where
+instance Set (SwaggerHandler m) (WG.SetCookie e name) where
   {-# INLINE setTrait #-}
   setTrait WG.SetCookie _ = SwaggerHandler pure

--- a/webgear-swagger/src/WebGear/Swagger/Trait/Header.hs
+++ b/webgear-swagger/src/WebGear/Swagger/Trait/Header.hs
@@ -35,14 +35,13 @@ import WebGear.Core.Handler (Description (..))
 import WebGear.Core.Modifiers (Existence (..))
 import WebGear.Core.Request (Request)
 import qualified WebGear.Core.Response as WG
-import WebGear.Core.Trait (Get (..), Set (..), TraitAbsence)
+import WebGear.Core.Trait (Get (..), Set (..))
 import qualified WebGear.Core.Trait.Header as WG
 import WebGear.Swagger.Handler (Documentation, SwaggerHandler (..), consumeDescription)
 
 instance
   ( KnownSymbol name
   , ToParamSchema val
-  , TraitAbsence (WG.RequestHeader Required ps name val) Request
   ) =>
   Get (SwaggerHandler m) (WG.RequestHeader Required ps name val) Request
   where
@@ -52,7 +51,6 @@ instance
 instance
   ( KnownSymbol name
   , ToParamSchema val
-  , TraitAbsence (WG.RequestHeader Optional ps name val) Request
   ) =>
   Get (SwaggerHandler m) (WG.RequestHeader Optional ps name val) Request
   where

--- a/webgear-swagger/src/WebGear/Swagger/Trait/Header.hs
+++ b/webgear-swagger/src/WebGear/Swagger/Trait/Header.hs
@@ -33,8 +33,6 @@ import Data.Text (Text)
 import GHC.TypeLits (KnownSymbol, symbolVal)
 import WebGear.Core.Handler (Description (..))
 import WebGear.Core.Modifiers (Existence (..))
-import WebGear.Core.Request (Request)
-import qualified WebGear.Core.Response as WG
 import WebGear.Core.Trait (Get (..), Set (..))
 import qualified WebGear.Core.Trait.Header as WG
 import WebGear.Swagger.Handler (Documentation, SwaggerHandler (..), consumeDescription)
@@ -43,7 +41,7 @@ instance
   ( KnownSymbol name
   , ToParamSchema val
   ) =>
-  Get (SwaggerHandler m) (WG.RequestHeader Required ps name val) Request
+  Get (SwaggerHandler m) (WG.RequestHeader Required ps name val)
   where
   {-# INLINE getTrait #-}
   getTrait WG.RequestHeader = SwaggerHandler $ addRequestHeader (Proxy @name) (Proxy @val) True
@@ -52,16 +50,16 @@ instance
   ( KnownSymbol name
   , ToParamSchema val
   ) =>
-  Get (SwaggerHandler m) (WG.RequestHeader Optional ps name val) Request
+  Get (SwaggerHandler m) (WG.RequestHeader Optional ps name val)
   where
   {-# INLINE getTrait #-}
   getTrait WG.RequestHeader = SwaggerHandler $ addRequestHeader (Proxy @name) (Proxy @val) False
 
-instance (KnownSymbol name) => Set (SwaggerHandler m) (WG.ResponseHeader Required name val) WG.Response where
+instance (KnownSymbol name) => Set (SwaggerHandler m) (WG.ResponseHeader Required name val) where
   {-# INLINE setTrait #-}
   setTrait WG.ResponseHeader _ = SwaggerHandler $ addResponseHeader (Proxy @name) (Proxy @val)
 
-instance (KnownSymbol name) => Set (SwaggerHandler m) (WG.ResponseHeader Optional name val) WG.Response where
+instance (KnownSymbol name) => Set (SwaggerHandler m) (WG.ResponseHeader Optional name val) where
   {-# INLINE setTrait #-}
   setTrait WG.ResponseHeader _ = SwaggerHandler $ addResponseHeader (Proxy @name) (Proxy @val)
 

--- a/webgear-swagger/src/WebGear/Swagger/Trait/Method.hs
+++ b/webgear-swagger/src/WebGear/Swagger/Trait/Method.hs
@@ -7,12 +7,11 @@ import Control.Lens ((%~), (&))
 import qualified Data.HashMap.Strict.InsOrd as Map
 import Data.Swagger (PathItem (..), paths)
 import Network.HTTP.Types (StdMethod (..))
-import WebGear.Core.Request (Request)
 import WebGear.Core.Trait (Get (..))
 import WebGear.Core.Trait.Method (Method (..))
 import WebGear.Swagger.Handler (SwaggerHandler (..), addRouteDocumentation)
 
-instance Get (SwaggerHandler m) Method Request where
+instance Get (SwaggerHandler m) Method where
   {-# INLINE getTrait #-}
   getTrait (Method method) = SwaggerHandler $ \doc -> do
     addRouteDocumentation $ doc & paths %~ Map.map (removeOtherMethods method)

--- a/webgear-swagger/src/WebGear/Swagger/Trait/Path.hs
+++ b/webgear-swagger/src/WebGear/Swagger/Trait/Path.hs
@@ -23,12 +23,12 @@ import WebGear.Core.Trait (Get (..), With)
 import WebGear.Core.Trait.Path (Path (..), PathEnd (..), PathVar (..), PathVarError (..))
 import WebGear.Swagger.Handler (SwaggerHandler (..), addRouteDocumentation)
 
-instance Get (SwaggerHandler m) Path Request where
+instance Get (SwaggerHandler m) Path where
   {-# INLINE getTrait #-}
   getTrait :: Path -> SwaggerHandler m (Request `With` ts) (Either () ())
   getTrait (Path p) = SwaggerHandler $ addRouteDocumentation . prependPath (unpack p)
 
-instance (KnownSymbol tag) => Get (SwaggerHandler m) (PathVar tag val) Request where
+instance (KnownSymbol tag) => Get (SwaggerHandler m) (PathVar tag val) where
   {-# INLINE getTrait #-}
   getTrait :: PathVar tag val -> SwaggerHandler m (Request `With` ts) (Either PathVarError val)
   getTrait PathVar =
@@ -50,7 +50,7 @@ instance (KnownSymbol tag) => Get (SwaggerHandler m) (PathVar tag val) Request w
             prependPath ("{" <> paramName <> "}") doc
               & allOperations . parameters <>~ [Inline param]
 
-instance Get (SwaggerHandler m) PathEnd Request where
+instance Get (SwaggerHandler m) PathEnd where
   {-# INLINE getTrait #-}
   getTrait :: PathEnd -> SwaggerHandler m (Request `With` ts) (Either () ())
   getTrait PathEnd = SwaggerHandler $ addRouteDocumentation . prependPath "/"

--- a/webgear-swagger/src/WebGear/Swagger/Trait/QueryParam.hs
+++ b/webgear-swagger/src/WebGear/Swagger/Trait/QueryParam.hs
@@ -21,12 +21,11 @@ import Data.Swagger (
 import GHC.TypeLits (KnownSymbol, symbolVal)
 import WebGear.Core.Handler (Description (..))
 import WebGear.Core.Modifiers (Existence (..))
-import WebGear.Core.Request (Request)
 import WebGear.Core.Trait (Get (..))
 import WebGear.Core.Trait.QueryParam (QueryParam (..))
 import WebGear.Swagger.Handler (Documentation (..), SwaggerHandler (..), consumeDescription)
 
-instance (KnownSymbol name) => Get (SwaggerHandler m) (QueryParam Required ps name val) Request where
+instance (KnownSymbol name) => Get (SwaggerHandler m) (QueryParam Required ps name val) where
   {-# INLINE getTrait #-}
   getTrait _ =
     let param =
@@ -43,7 +42,7 @@ instance (KnownSymbol name) => Get (SwaggerHandler m) (QueryParam Required ps na
             }
      in SwaggerHandler $ addParam param
 
-instance (KnownSymbol name) => Get (SwaggerHandler m) (QueryParam Optional ps name val) Request where
+instance (KnownSymbol name) => Get (SwaggerHandler m) (QueryParam Optional ps name val) where
   {-# INLINE getTrait #-}
   getTrait _ =
     let param =

--- a/webgear-swagger/src/WebGear/Swagger/Trait/QueryParam.hs
+++ b/webgear-swagger/src/WebGear/Swagger/Trait/QueryParam.hs
@@ -22,11 +22,11 @@ import GHC.TypeLits (KnownSymbol, symbolVal)
 import WebGear.Core.Handler (Description (..))
 import WebGear.Core.Modifiers (Existence (..))
 import WebGear.Core.Request (Request)
-import WebGear.Core.Trait (Get (..), TraitAbsence)
+import WebGear.Core.Trait (Get (..))
 import WebGear.Core.Trait.QueryParam (QueryParam (..))
 import WebGear.Swagger.Handler (Documentation (..), SwaggerHandler (..), consumeDescription)
 
-instance (KnownSymbol name, TraitAbsence (QueryParam Required ps name val) Request) => Get (SwaggerHandler m) (QueryParam Required ps name val) Request where
+instance (KnownSymbol name) => Get (SwaggerHandler m) (QueryParam Required ps name val) Request where
   {-# INLINE getTrait #-}
   getTrait _ =
     let param =
@@ -43,7 +43,7 @@ instance (KnownSymbol name, TraitAbsence (QueryParam Required ps name val) Reque
             }
      in SwaggerHandler $ addParam param
 
-instance (KnownSymbol name, TraitAbsence (QueryParam Optional ps name val) Request) => Get (SwaggerHandler m) (QueryParam Optional ps name val) Request where
+instance (KnownSymbol name) => Get (SwaggerHandler m) (QueryParam Optional ps name val) Request where
   {-# INLINE getTrait #-}
   getTrait _ =
     let param =

--- a/webgear-swagger/src/WebGear/Swagger/Trait/Status.hs
+++ b/webgear-swagger/src/WebGear/Swagger/Trait/Status.hs
@@ -30,7 +30,7 @@ import WebGear.Core.Trait (Set, With, setTrait)
 import WebGear.Core.Trait.Status (Status (..))
 import WebGear.Swagger.Handler (SwaggerHandler (..), addRootPath, consumeDescription)
 
-instance Set (SwaggerHandler m) Status WG.Response where
+instance Set (SwaggerHandler m) Status where
   {-# INLINE setTrait #-}
   setTrait ::
     Status ->


### PR DESCRIPTION
A few changes to the core API to improve usability:

Removed `Trait` and `TraitAbsence` type classes. These are replaced with top-level open type synonym families to reduce verbosity.

Made some types and type classes less general to reduce verbosity of
type annotations. This also reduces complexity and improves the
learning curve of new users.

- Removed the `a` type parameter from the following types/type
  classes. They only work with `Request` type now.
  - `Absence`
  - `Prerequisite`
  - `Get`
  - `Gets`
  - `probe`
- Removed the `a` type parameter from the following types/type
  classes. They only work with `Response` type now.
  - `Set`
  - `Sets`
  - `plant`
 
These are major breaking changes but it is straightforward to update any existing code.