### PR TITLE
Make FormData backend monadic

### DIFF
--- a/webgear-core/CHANGELOG.md
+++ b/webgear-core/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Make FormData backend monadic (breaking change) (#59)
+
 ## [1.4.0] - 2025-05-19
 
 ### Added

--- a/webgear-core/src/WebGear/Core/MIMETypes.hs
+++ b/webgear-core/src/WebGear/Core/MIMETypes.hs
@@ -59,9 +59,9 @@ instance MIMEType JSON where
 --------------------------------------------------------------------------------
 
 -- | The multipart/form-data MIME type
-data FormData a = FormData
+data FormData m a = FormData
   { parseOptions :: Wai.Parse.ParseRequestBodyOptions
-  , backendOptions :: Wai.Parse.BackEnd a
+  , backendOptions :: m (Wai.Parse.BackEnd a)
   }
 
 {- | Result of parsing a multipart/form-data body from a request.
@@ -72,8 +72,8 @@ data FormDataResult a = FormDataResult
   , formDataFiles :: [Wai.Parse.File a]
   }
 
-instance MIMEType (FormData a) where
-  mimeType :: FormData a -> HTTP.MediaType
+instance MIMEType (FormData m a) where
+  mimeType :: FormData m a -> HTTP.MediaType
   mimeType _ = "multipart/form-data"
   {-# INLINE mimeType #-}
 

--- a/webgear-openapi/CHANGELOG.md
+++ b/webgear-openapi/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Make FormData backend monadic (breaking change) (#59)
+
 ## [1.4.0] - 2025-05-19
 
 ### Added

--- a/webgear-server/CHANGELOG.md
+++ b/webgear-server/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Make FormData backend monadic (breaking change) (#59)
+
 ## [1.4.0] - 2025-05-19
 
 ### Added

--- a/webgear-swagger-ui/CHANGELOG.md
+++ b/webgear-swagger-ui/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Make FormData backend monadic (breaking change) (#59)
+
 ## [1.4.0] - 2025-05-19
 
 ### Added

--- a/webgear-swagger/CHANGELOG.md
+++ b/webgear-swagger/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Make FormData backend monadic (breaking change) (#59)
+
 ## [1.4.0] - 2025-05-19
 
 ### Added


### PR DESCRIPTION
Some implementations of `Network.Wai.Parse.Backend` - such as `tempFileBackEnd` - are inherently computed in a monad. This change makes the `FormData` trait a monadically computed value instead of a pure one.

This is a breaking change to the API, but it is trivial for callers to migrate.